### PR TITLE
Remove platform specific sleep calls, fix *nix

### DIFF
--- a/TShock.Modifications.Platform/PlatformModification.cs
+++ b/TShock.Modifications.Platform/PlatformModification.cs
@@ -1,8 +1,10 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using Mono.Cecil;
 using Mono.Cecil.Cil;
 using OTAPI.Patcher.Engine.Modification;
+using OTAPI.Patcher.Engine.Extensions;
 
 namespace Mintaka.Modifications.Platform
 {
@@ -41,6 +43,23 @@ namespace Mintaka.Modifications.Platform
 			processor.Append(Instruction.Create(OpCodes.Ldsflda, field));
 			processor.Append(Instruction.Create(OpCodes.Call, changePlatformMethodDefinition));
 			processor.Append(Instruction.Create(OpCodes.Ret));
+
+			RemovePlatformSpecificSleep();
+		}
+
+		public void RemovePlatformSpecificSleep()
+		{
+			MethodDefinition def = this.SourceDefinition.Type("Terraria.Main").Method("NeverSleep");
+
+			var processor = def.Body.GetILProcessor();
+			processor.Body.Instructions.Clear();
+			processor.Append(Instruction.Create(OpCodes.Ret));
+
+			MethodDefinition def2 = this.SourceDefinition.Type("Terraria.Main").Method("YouCanSleepNow");
+
+			var processor2 = def2.Body.GetILProcessor();
+			processor2.Body.Instructions.Clear();
+			processor2.Append(Instruction.Create(OpCodes.Ret));
 		}
 
 	}


### PR DESCRIPTION
This is a ghetto monkey patch to fix the fact that the server binary
doesn't work on Linux + macOS. Since the actual call is external it's
easier to just block things that call it rather than the method call
that's imported from kernel32.dll itself.