### PR TITLE
Add Explosives

### DIFF
--- a/TerrariaServerAPI/Program.cs
+++ b/TerrariaServerAPI/Program.cs
@@ -23,10 +23,17 @@ namespace OTAPI.Shims.TShock
 				ItemID.RocketLauncher,
 				ItemID.RocketII,
 				ItemID.RocketIV,
+				ItemID.ClusterRocketII,
+				ItemID.MiniNukeII,
 				ItemID.SnowmanCannon,
 				ItemID.StickyDynamite,
 				ItemID.BouncyBomb,
-				ItemID.BombFish
+				ItemID.BombFish,
+				// The following are classified as explosives untill we can figure out a better way.
+				ItemID.DryRocket,
+				ItemID.WetRocket,
+				ItemID.LavaRocket,
+				ItemID.HoneyRocket,
 			});
 
 			//Set corrupt tiles to true, as they aren't in vanilla


### PR DESCRIPTION
Added: Cluster Rocket II, Mini Nuke II to the explosives list.

Dry Rocket, Wet Rocket, Lava Rocket and Honey Rocket Are technically considered explosives since they modify/create/delete tiles.