### PR TITLE
Add -difficulty cli flag

### DIFF
--- a/TerrariaServerAPI/TerrariaApi.Server/ServerApi.cs
+++ b/TerrariaServerAPI/TerrariaApi.Server/ServerApi.cs
@@ -235,7 +235,7 @@ namespace TerrariaApi.Server
 						{
 							if (!isAutoCreating)
 							{
-								// If we're not creating a world, ignore this flag
+								LogWriter.ServerWriteLine("Ignoring difficulty command line flag because server is starting in interactive mode without autocreate", TraceLevel.Warning);
 								continue;
 							}
 

--- a/TerrariaServerAPI/TerrariaApi.Server/ServerApi.cs
+++ b/TerrariaServerAPI/TerrariaApi.Server/ServerApi.cs
@@ -239,7 +239,7 @@ namespace TerrariaApi.Server
 								continue;
 							}
 
-							// If the arg isn't an integer, or its an incorrect value
+							// If the arg isn't an integer, or its an incorrect value, we want to ignore it
 							if (int.TryParse(arg.Value, out int dif))
 							{
 								if (dif >= 0 && dif <= 3)

--- a/TerrariaServerAPI/TerrariaApi.Server/ServerApi.cs
+++ b/TerrariaServerAPI/TerrariaApi.Server/ServerApi.cs
@@ -128,6 +128,8 @@ namespace TerrariaApi.Server
 		{
 			Dictionary<string, string> args = Utils.ParseArguements(parms);
 
+			bool isAutoCreating = false;
+
 			foreach (KeyValuePair<string, string> arg in args)
 			{
 				switch (arg.Key.ToLower())
@@ -225,6 +227,30 @@ namespace TerrariaApi.Server
 					case "-autocreate":
 						{
 							game.autoCreate(arg.Value);
+							isAutoCreating = true;
+
+							break;
+						}
+					case "-difficulty":
+						{
+							if (!isAutoCreating)
+							{
+								// If we're not creating a world, ignore this flag
+								continue;
+							}
+
+							// If the arg isn't an integer, or its an incorrect value
+							if (int.TryParse(arg.Value, out int dif))
+							{
+								if (dif >= 0 && dif <= 3)
+								{
+									Main.GameMode = dif;
+								}
+							}
+							else
+							{
+								LogWriter.ServerWriteLine("Unexpected difficulty value. Expected values are 0-3.", TraceLevel.Info);
+							}
 
 							break;
 						}

--- a/TerrariaServerAPI/TerrariaApi.Server/ServerApi.cs
+++ b/TerrariaServerAPI/TerrariaApi.Server/ServerApi.cs
@@ -249,7 +249,7 @@ namespace TerrariaApi.Server
 							}
 							else
 							{
-								LogWriter.ServerWriteLine("Unexpected difficulty value. Expected values are 0-3.", TraceLevel.Info);
+								LogWriter.ServerWriteLine("Unexpected difficulty value. Expected values are 0-3.", TraceLevel.Warning);
 							}
 
 							break;


### PR DESCRIPTION
To allow autocreating worlds with a defined difficulty flag.
Requested at https://github.com/Pryaxis/TShock/issues/2177.


Requirements:
* It should be tied with the -autocreate parameter, and ignore it in case of not having it.
* It should use one of these 4 possible values: 0 (classic), 1 (expert), 2 (master) or 3 (journey).
