### PR TITLE
Switch IsInputRedirected to a CLI flag

### DIFF
--- a/TerrariaServerAPI/TerrariaApi.Server/Hooking/ServerHooks.cs
+++ b/TerrariaServerAPI/TerrariaApi.Server/Hooking/ServerHooks.cs
@@ -1,5 +1,6 @@
 ﻿using OTAPI;
 using System;
+using System.Linq;
 using Terraria;
 
 namespace TerrariaApi.Server.Hooking
@@ -23,9 +24,9 @@ namespace TerrariaApi.Server.Hooking
 
 		static HookResult OnStartCommandThread()
 		{
-			if (Console.IsInputRedirected == true)
+			if(Environment.GetCommandLineArgs().Any(x => x.Equals("-disable-commands")))
 			{
-				Console.WriteLine("TerrariaServer is running in the background and input is disabled.");
+				Console.WriteLine("Command thread has been disabled.");
 				return HookResult.Cancel;
 			}
 


### PR DESCRIPTION
Alternate to #185 as i don't believe we should be using Console.IsInputRedirected in this situation.
Instead disable it explicitly, rather than automatically and undoing it (making it more confusing).

Tested using gist: https://gist.github.com/DeathCradle/570f9be7b4a498cacc0ec2bef35c535b
Drop in this TerrariaServer.exe, commands continue to work, unless -disable-commands is supplied.

Root source before file shuffle: https://github.com/Pryaxis/TSAPI/blob/ec4e59ea0c5fd5e21fbb4742c844863016a901a7/Terraria/Main.cs#L10020