### PR TITLE
Change base path for plugins to use AppContext.BaseDirectory

### DIFF
--- a/TerrariaServerAPI/TerrariaApi.Server/ServerApi.cs
+++ b/TerrariaServerAPI/TerrariaApi.Server/ServerApi.cs
@@ -90,7 +90,7 @@ namespace TerrariaApi.Server
 
 			ServerApi.game = game;
 			HandleCommandLine(commandLineArgs);
-			ServerPluginsDirectoryPath = Path.Combine(Environment.CurrentDirectory, PluginsPath);
+			ServerPluginsDirectoryPath = Path.Combine(AppContext.BaseDirectory, PluginsPath);
 
 			if (!Directory.Exists(ServerPluginsDirectoryPath))
 			{


### PR DESCRIPTION
See https://github.com/Pryaxis/TShock/issues/2674
If someone uses a startup script from outside the assembly directory, this will allow plugins to load.

Note: there is still the issue of directories, logs, and plugins still creating in the current directory by default. that is an existing issue. this is a follow up after the above issue, which if used in such a way, plugins wont load.