### PR TITLE
Fix tombstones and other "disable projectile" settings

### DIFF
--- a/TerrariaServerAPI/TerrariaApi.Server/Hooking/ProjectileHooks.cs
+++ b/TerrariaServerAPI/TerrariaApi.Server/Hooking/ProjectileHooks.cs
@@ -21,8 +21,8 @@ namespace TerrariaApi.Server.Hooking
 
 		private static void OnSetDefaults(On.Terraria.Projectile.orig_SetDefaults orig, Projectile projectile, int type)
 		{
-			_hookManager.InvokeProjectileSetDefaults(ref type, projectile);
 			orig(projectile, type);
+			_hookManager.InvokeProjectileSetDefaults(ref type, projectile);
 		}
 
 		private static void OnAI(On.Terraria.Projectile.orig_AI orig, Projectile projectile)


### PR DESCRIPTION
This moves the projectile hook to after the SetDefaults call, matching OTAPI2 functionality, and allowing the type to be checked correctly. Without this, the tombstone ID's will not be ready for tshock to use.

see here for old code: https://github.com/Pryaxis/TSAPI/blob/4c2075fbdd7e9b17dd96d6495fe9f491a2af0bbb/TerrariaServerAPI/TerrariaApi.Server/Hooking/ProjectileHooks.cs#L22

Context:
![Screen Shot 2022-10-09 at 9 01 20 pm](https://user-images.githubusercontent.com/776327/194753177-08e158cf-21f9-456c-8bb0-ec380fad0ab7.png)
