### PR TITLE
Add -additionalplugins flag

### DIFF
--- a/TerrariaServerAPI/TerrariaApi.Server/ServerApi.cs
+++ b/TerrariaServerAPI/TerrariaApi.Server/ServerApi.cs
@@ -19,6 +19,7 @@ namespace TerrariaApi.Server
 	public static class ServerApi
 	{
 		public const string PluginsPath = "ServerPlugins";
+		public static string? AdditionalPluginsPath { get; private set; } = null;
 
 		public static readonly Version ApiVersion = new Version(2, 1, 0, 0);
 		private static Main game;
@@ -263,6 +264,9 @@ namespace TerrariaApi.Server
 					case "-crashdir":
 						CrashReporter.crashReportPath = arg.Value;
 						break;
+					case "-additionalplugins":
+						AdditionalPluginsPath = arg.Value;
+						break;
 				}
 			}
 		}
@@ -306,6 +310,12 @@ namespace TerrariaApi.Server
 
 			List<FileInfo> fileInfos = new DirectoryInfo(ServerPluginsDirectoryPath).GetFiles("*.dll").ToList();
 			fileInfos.AddRange(new DirectoryInfo(ServerPluginsDirectoryPath).GetFiles("*.dll-plugin"));
+			if (AdditionalPluginsPath is string additionalPath)
+			{
+				var di = new DirectoryInfo(Path.Combine(AppContext.BaseDirectory, additionalPath));
+				fileInfos.AddRange(di.GetFiles("*.dll"));
+				fileInfos.AddRange(di.GetFiles("*.dll-plugin"));
+			}
 
 			Dictionary<TerrariaPlugin, Stopwatch> pluginInitWatches = new Dictionary<TerrariaPlugin, Stopwatch>();
 			foreach (FileInfo fileInfo in fileInfos)


### PR DESCRIPTION
This makes the orchestration of multiple similar-but-not-identical TShock instances easier; as shared plugins can go in the default ServerPlugins directory, and instance-specific plugins can go in a directory passed via this flag when launching an instance.