### PR TITLE
-nolog startup flag

### DIFF
--- a/TerrariaServerAPI/TerrariaApi.Server/LogWriterManager.cs
+++ b/TerrariaServerAPI/TerrariaApi.Server/LogWriterManager.cs
@@ -17,13 +17,20 @@ namespace TerrariaApi.Server
 		}
 		public string LogWriterName
 		{
-			get { return this.WrappedLogWriter.Name; }
+			get { return this.WrappedLogWriter?.Name; }
 		}
 
-		internal LogWriterManager()
+		/// <param name="enabled">
+		/// If set to false, no default log writer will be set at first, but a new one can be added with
+		/// <see cref="Attach(ILogWriter)"/> later.
+		/// </param>
+		internal LogWriterManager(bool enabled)
 		{
-			this.DefaultLogWriter = new ServerLogWriter();
-			this.WrappedLogWriter = this.DefaultLogWriter;
+			if (enabled)
+			{
+				this.DefaultLogWriter = new ServerLogWriter();
+				this.WrappedLogWriter = this.DefaultLogWriter;
+			}
 		}
 
 		public void Attach(ILogWriter newLogWriter)
@@ -57,7 +64,7 @@ namespace TerrariaApi.Server
 
 			if (detachException != null)
 				this.ServerWriteLine(
-					string.Format("Log writer \"{0}\" had thrown an unexpected exception:\n{1}", prevLogWriter.Name, detachException), 
+					string.Format("Log writer \"{0}\" has thrown an unexpected exception:\n{1}", prevLogWriter?.Name, detachException), 
 					TraceLevel.Error);
 		}
 
@@ -72,7 +79,7 @@ namespace TerrariaApi.Server
 			}
 			catch (Exception ex)
 			{
-				DefaultLogWriter.ServerWriteLine(
+				DefaultLogWriter?.ServerWriteLine(
 					string.Format("Log writer \"{0}\" has thrown an unexpected exception:\n{1}", this.LogWriterName, ex), TraceLevel.Error);
 			}
 
@@ -81,13 +88,16 @@ namespace TerrariaApi.Server
 
 		internal void ServerWriteLine(string message, TraceLevel kind)
 		{
+			if (this.WrappedLogWriter == null)
+				return;
+
 			try
 			{
 				this.WrappedLogWriter.ServerWriteLine(message, kind);
 			}
 			catch (Exception ex)
 			{
-				this.DefaultLogWriter.ServerWriteLine(string.Format(
+				this.DefaultLogWriter?.ServerWriteLine(string.Format(
 					"The attached log writer \"{0}\" has thrown an unexpected exception:\n{1}", this.LogWriterName, ex),
 					TraceLevel.Error);
 			}
@@ -95,13 +105,16 @@ namespace TerrariaApi.Server
 
 		public void PluginWriteLine(TerrariaPlugin plugin, string message, TraceLevel kind)
 		{
+			if (this.WrappedLogWriter == null)
+				return;
+
 			try
 			{
 				this.WrappedLogWriter.PluginWriteLine(plugin, message, kind);
 			}
 			catch (Exception ex)
 			{
-				DefaultLogWriter.ServerWriteLine(string.Format(
+				DefaultLogWriter?.ServerWriteLine(string.Format(
 					"The attached log writer \"{0}\" has thrown an unexpected exception:\n{1}", this.LogWriterName, ex),
 					TraceLevel.Error);
 			}

--- a/TerrariaServerAPI/TerrariaApi.Server/ServerApi.cs
+++ b/TerrariaServerAPI/TerrariaApi.Server/ServerApi.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Diagnostics;
 using System.IO;
-using System.Net;
 using System.Reflection;
 using System.Linq;
 using Terraria;
@@ -68,8 +67,9 @@ namespace TerrariaApi.Server
 
 		static ServerApi()
 		{
+			Dictionary<string, string> args = Utils.ParseArguements(Environment.GetCommandLineArgs());
 			Hooks = new HookManager();
-			LogWriter = new LogWriterManager();
+			LogWriter = new LogWriterManager(enabled: !args.ContainsKey("-nolog"));
 			Profiler = new ProfilerManager();
 
 			UseAsyncSocketsInMono = false;
@@ -133,6 +133,8 @@ namespace TerrariaApi.Server
 
 			foreach (KeyValuePair<string, string> arg in args)
 			{
+				// Note that the flag -nolog also exists in the constructor, but it can't be here because
+				// the log writer initializes before this code is run
 				switch (arg.Key.ToLower())
 				{
 					case "-ignoreversion":
@@ -162,6 +164,7 @@ namespace TerrariaApi.Server
 							break;
 						}
 					case "-players":
+					case "-maxplayers":
 						{
 							int playerCount;
 							if (!Int32.TryParse(arg.Value, out playerCount))
@@ -175,16 +178,13 @@ namespace TerrariaApi.Server
 
 							break;
 						}
-					case "-maxplayers":
-						goto case "-players";
 					case "-pass":
+					case "-password":
 						{
 							Netplay.ServerPassword = arg.Value;
 
 							break;
 						}
-					case "-password":
-						goto case "-pass";
 					case "-worldname":
 						{
 							game.SetWorldName(arg.Value);


### PR DESCRIPTION
The reason for this flag is if you're running a multi instance proxy setup, in which case multiple writes to `ServerLog.txt` would cause an error because multiple writers are writing to the same file. While you can use `Attach()` to replace the default writer with something else that doesn't have this problem, there is still a small window where the writer is opened and written to before you can do that, making it possible for such a startup error to happen if the timing is bad. While this sets the default writer to nothing, you can still use `Attach()` to attach a new writer in your own plugin.