### PR TITLE
Respect OTAPI hook result

### DIFF
--- a/TerrariaServerAPI/TerrariaApi.Server/Hooking/GameHooks.cs
+++ b/TerrariaServerAPI/TerrariaApi.Server/Hooking/GameHooks.cs
@@ -34,6 +34,10 @@ namespace TerrariaApi.Server.Hooking
 
 		private static void OnHardmodeTileUpdate(object sender, Hooks.WorldGen.HardmodeTileUpdateEventArgs e)
 		{
+			if (e.Result == HookResult.Cancel)
+			{
+				return;
+			}
 			if (_hookManager.InvokeGameHardmodeTileUpdate(e.X, e.Y, e.Type))
 			{
 				e.Result = HookResult.Cancel;
@@ -42,6 +46,10 @@ namespace TerrariaApi.Server.Hooking
 
 		private static void OnHardmodeTilePlace(object sender, Hooks.WorldGen.HardmodeTilePlaceEventArgs e)
 		{
+			if (e.Result == HardmodeTileUpdateResult.Cancel)
+			{
+				return;
+			}
 			if (_hookManager.InvokeGameHardmodeTileUpdate(e.X, e.Y, e.Type))
 			{
 				e.Result = HardmodeTileUpdateResult.Cancel;
@@ -63,6 +71,10 @@ namespace TerrariaApi.Server.Hooking
 
 		private static void OnItemMechSpawn(object sender, Hooks.Item.MechSpawnEventArgs e)
 		{
+			if (e.Result == HookResult.Cancel)
+			{
+				return;
+			}
 			if (!_hookManager.InvokeGameStatueSpawn(e.Num2, e.Num3, e.Num, (int)(e.X / 16f), (int)(e.Y / 16f), e.Type, false))
 			{
 				e.Result = HookResult.Cancel;
@@ -71,6 +83,10 @@ namespace TerrariaApi.Server.Hooking
 
 		private static void OnNpcMechSpawn(object sender, Hooks.NPC.MechSpawnEventArgs e)
 		{
+			if (e.Result == HookResult.Cancel)
+			{
+				return;
+			}
 			if (!_hookManager.InvokeGameStatueSpawn(e.Num2, e.Num3, e.Num, (int)(e.X / 16f), (int)(e.Y / 16f), e.Type, true))
 			{
 				e.Result = HookResult.Cancel;

--- a/TerrariaServerAPI/TerrariaApi.Server/Hooking/ItemHooks.cs
+++ b/TerrariaServerAPI/TerrariaApi.Server/Hooking/ItemHooks.cs
@@ -40,6 +40,10 @@ namespace TerrariaApi.Server.Hooking
 
 		private static void OnQuickStack(object sender, Hooks.Chest.QuickStackEventArgs e)
 		{
+			if (e.Result == HookResult.Cancel)
+			{
+				return;
+			}
 			if (_hookManager.InvokeItemForceIntoChest(Main.chest[e.ChestIndex], e.Item, Main.player[e.PlayerId]))
 			{
 				e.Result = HookResult.Cancel;

--- a/TerrariaServerAPI/TerrariaApi.Server/Hooking/NetHooks.cs
+++ b/TerrariaServerAPI/TerrariaApi.Server/Hooking/NetHooks.cs
@@ -50,6 +50,10 @@ namespace TerrariaApi.Server.Hooking
 
 		static void OnSendData(object sender, Hooks.NetMessage.SendDataEventArgs e)
 		{
+			if (e.Result == HookResult.Cancel)
+			{
+				return;
+			}
 			if (e.Event == HookEvent.Before)
 			{
 				var msgType = e.MsgType;
@@ -110,6 +114,10 @@ namespace TerrariaApi.Server.Hooking
 
 		static void OnReceiveData(object sender, Hooks.MessageBuffer.GetDataEventArgs e)
 		{
+			if (e.Result == HookResult.Cancel)
+			{
+				return;
+			}
 			if (!Enum.IsDefined(typeof(PacketTypes), (int)e.PacketId))
 			{
 				e.Result = HookResult.Cancel;
@@ -141,6 +149,10 @@ namespace TerrariaApi.Server.Hooking
 
 		static void OnSendBytes(object sender, Hooks.NetMessage.SendBytesEventArgs e)
 		{
+			if (e.Result == HookResult.Cancel)
+			{
+				return;
+			}
 			if (_hookManager.InvokeNetSendBytes(Netplay.Clients[e.RemoteClient], e.Data, e.Offset, e.Size))
 			{
 				e.Result = HookResult.Cancel;
@@ -149,6 +161,10 @@ namespace TerrariaApi.Server.Hooking
 
 		static void OnNameCollision(object sender, Hooks.MessageBuffer.NameCollisionEventArgs e)
 		{
+			if (e.Result == HookResult.Cancel)
+			{
+				return;
+			}
 			if (_hookManager.InvokeNetNameCollision(e.Player.whoAmI, e.Player.name))
 			{
 				e.Result = HookResult.Cancel;

--- a/TerrariaServerAPI/TerrariaApi.Server/Hooking/NpcHooks.cs
+++ b/TerrariaServerAPI/TerrariaApi.Server/Hooking/NpcHooks.cs
@@ -72,6 +72,10 @@ namespace TerrariaApi.Server.Hooking
 
 		static void OnSpawn(object sender, Hooks.NPC.SpawnEventArgs e)
 		{
+			if (e.Result == HookResult.Cancel)
+			{
+				return;
+			}
 			var index = e.Index;
 			if (_hookManager.InvokeNpcSpawn(ref index))
 			{
@@ -82,6 +86,10 @@ namespace TerrariaApi.Server.Hooking
 
 		static void OnDropLoot(object sender, Hooks.NPC.DropLootEventArgs e)
 		{
+			if (e.Result == HookResult.Cancel)
+			{
+				return;
+			}
 			if (e.Event == HookEvent.Before)
 			{
 				var Width = e.Width;
@@ -129,6 +137,10 @@ namespace TerrariaApi.Server.Hooking
 
 		static void OnBossBagItem(object sender, Hooks.NPC.BossBagEventArgs e)
 		{
+			if (e.Result == HookResult.Cancel)
+			{
+				return;
+			}
 			var Width = e.Width;
 			var Height = e.Height;
 			var Type = e.Type;

--- a/TerrariaServerAPI/TerrariaApi.Server/Hooking/ServerHooks.cs
+++ b/TerrariaServerAPI/TerrariaApi.Server/Hooking/ServerHooks.cs
@@ -35,6 +35,10 @@ namespace TerrariaApi.Server.Hooking
 
 		static void OnProcess(object sender, Hooks.Main.CommandProcessEventArgs e)
 		{
+			if (e.Result == HookResult.Cancel)
+			{
+				return;
+			}
 			if (_hookManager.InvokeServerCommand(e.Command))
 			{
 				e.Result = HookResult.Cancel;

--- a/TerrariaServerAPI/TerrariaApi.Server/Hooking/WiringHooks.cs
+++ b/TerrariaServerAPI/TerrariaApi.Server/Hooking/WiringHooks.cs
@@ -20,6 +20,10 @@ namespace TerrariaApi.Server.Hooking
 
 		static void OnAnnouncementBox(object sender, Hooks.Wiring.AnnouncementBoxEventArgs e)
 		{
+			if (e.Result == HookResult.Cancel)
+			{
+				return;
+			}
 			if (_hookManager.InvokeWireTriggerAnnouncementBox(Wiring.CurrentUser, e.X, e.Y, e.SignId, Main.sign[e.SignId].text))
 			{
 				e.Result = HookResult.Cancel;

--- a/TerrariaServerAPI/TerrariaApi.Server/Hooking/WorldHooks.cs
+++ b/TerrariaServerAPI/TerrariaApi.Server/Hooking/WorldHooks.cs
@@ -27,6 +27,10 @@ namespace TerrariaApi.Server.Hooking
 
 		static void OnPressurePlate(object sender, Hooks.Collision.PressurePlateEventArgs e)
 		{
+			if (e.Result == HookResult.Cancel)
+			{
+				return;
+			}
 			if (e.Entity is NPC npc)
 			{
 				if (_hookManager.InvokeNpcTriggerPressurePlate(npc, e.X, e.Y))
@@ -62,6 +66,10 @@ namespace TerrariaApi.Server.Hooking
 
 		static void OnDropMeteor(object sender, Hooks.WorldGen.MeteorEventArgs e)
 		{
+			if (e.Result == HookResult.Cancel)
+			{
+				return;
+			}
 			if (_hookManager.InvokeWorldMeteorDrop(e.X, e.Y))
 			{
 				e.Result = HookResult.Cancel;


### PR DESCRIPTION
The TSAPI's hooks are always triggered, no matter if it is already cancelled. The plugins that use those TSAPI hooks are unable to determine if they are cancelled and always process them at least once.