### PR TITLE
Show IL offsets

### DIFF
--- a/TerrariaServerAPI/TerrariaApi.Server/ServerApi.cs
+++ b/TerrariaServerAPI/TerrariaApi.Server/ServerApi.cs
@@ -75,6 +75,7 @@ namespace TerrariaApi.Server
 
 		static ServerApi()
 		{
+			AppContext.SetSwitch("Switch.System.Diagnostics.StackTrace.ShowILOffsets", true);
 			Dictionary<string, string> args = Utils.ParseArguements(Environment.GetCommandLineArgs());
 			Hooks = new HookManager();
 			LogWriter = new LogWriterManager(enabled: !args.ContainsKey("-nolog"));


### PR DESCRIPTION
This PR ticks an option that lets `System.Diagnostics.StackTrace` show the IL offset when PDB information is unavailable