### PR TITLE
Also load symbols in AssemblyResolve

### DIFF
--- a/TerrariaServerAPI/TerrariaApi.Server/ServerApi.cs
+++ b/TerrariaServerAPI/TerrariaApi.Server/ServerApi.cs
@@ -517,7 +517,8 @@ namespace TerrariaApi.Server
 					Assembly assembly;
 					if (!loadedAssemblies.TryGetValue(fileName, out assembly))
 					{
-						assembly = Assembly.Load(File.ReadAllBytes(path));
+						var pdbPath = Path.ChangeExtension(fileName, ".pdb");
+						assembly = Assembly.Load(File.ReadAllBytes(path), File.Exists(pdbPath) ? File.ReadAllBytes(pdbPath) : null);
 						// We just do this to return a proper error message incase this is a resolved plugin assembly
 						// referencing an old TerrariaServer version.
 						if (!InvalidateAssembly(assembly, fileName))


### PR DESCRIPTION
A prior PR already added PDB loading for plugins, and this PR extends that to any assemblies loaded in AssemblyResolve