### PR TITLE
Upgrade to .NET 9 and OTAPI Static Hooks for ARM64

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,11 +18,11 @@ jobs:
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
-      - uses: actions/setup-dotnet@v3
+      - uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: '6.0.100'
+          dotnet-version: 9.0.x
 
       - name: MonoMod dev build
         run: dotnet nuget add source https://pkgs.dev.azure.com/MonoMod/MonoMod/_packaging/DevBuilds%40Local/nuget/v3/index.json -n DevBuilds@Local

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,8 +12,28 @@ on:
 jobs:
   # This workflow contains a single job called "build"
   build:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ 
+          {
+            name: Windows,
+            runs-on: windows-latest,
+          },
+          {
+            name: Ubuntu,
+            runs-on: ubuntu-latest,
+          },
+          {
+            name: MacOS,
+            runs-on: macos-latest,
+          }
+        ]
+
     # The type of runner that the job will run on
-    runs-on: windows-latest
+    runs-on: ${{ matrix.os.runs-on }}
+
+    name: ${{ matrix.os.name }}
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
@@ -32,9 +52,3 @@ jobs:
 
       - name: Run tests
         run: dotnet test --filter "FullyQualifiedName!~TerrariaServerAPI.Tests.Benchmarks"
-        
-      # example task for the release CI 
-      # - name: "Releasing to NuGet: TSAPI"
-      #   env:
-      #     NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
-      #   run: dotnet nuget push ./TerrariaServerAPI/bin/Release/TerrariaServer.*.nupkg --source https://api.nuget.org/v3/index.json --api-key "$env:NUGET_API_KEY"

--- a/.github/workflows/nuget.yml
+++ b/.github/workflows/nuget.yml
@@ -11,11 +11,11 @@ jobs:
     environment: release
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Setup .NET
-      uses: actions/setup-dotnet@v3
+      uses: actions/setup-dotnet@v4
       with:
-        dotnet-version: 6.0.400
+        dotnet-version: 9.0.x
     - name: Restore dependencies
       run: dotnet restore
     - name: Build

--- a/TerrariaServerAPI.Tests/BaseTest.cs
+++ b/TerrariaServerAPI.Tests/BaseTest.cs
@@ -1,5 +1,6 @@
 ﻿using NUnit.Framework;
 using System.Runtime.InteropServices;
+using Terraria.Utilities;
 
 namespace TerrariaServerAPI.Tests;
 
@@ -20,7 +21,8 @@ public class BaseTest
 				invoked = true;
 				// DedServ typically requires input, so no need to continue execution
 				args.ContinueExecution = false;
-				// DedServ calls the following method, which is needed for subsequent tests
+				// DedServ calls the following, which is needed for subsequent tests
+				global::Terraria.Main.rand = new UnifiedRandom();
 				instance.Initialize();
 			};
 			HookEvents.Terraria.Main.DedServ += cb;

--- a/TerrariaServerAPI.Tests/BaseTest.cs
+++ b/TerrariaServerAPI.Tests/BaseTest.cs
@@ -12,20 +12,21 @@ public class BaseTest
 	[OneTimeSetUp]
 	public void EnsureInitialised()
 	{
+		TestContext.Out.WriteLine($"Test architecture {RuntimeInformation.ProcessArchitecture}");
+
 		if (!_initialized)
 		{
-			var are = new AutoResetEvent(false);
+			AutoResetEvent are = new(false);
 			Exception? error = null;
-			HookEvents.HookDelegate<global::Terraria.Main,HookEvents.Terraria.Main. DedServEventArgs> cb = (instance, args) =>
+			HookEvents.HookDelegate<global::Terraria.Main, HookEvents.Terraria.Main.DedServEventArgs> cb = (instance, args) =>
 			{
 				instance.Initialize();
 				are.Set();
 				_initialized = true;
-				Console.WriteLine($"Server init process successful for architecture {RuntimeInformation.ProcessArchitecture}");
 			};
 			HookEvents.Terraria.Main.DedServ += cb;
 
-			global::TerrariaApi.Server.Program.Main(new string[] { });
+			global::TerrariaApi.Server.Program.Main([]);
 
 			_initialized = are.WaitOne(TimeSpan.FromSeconds(30));
 

--- a/TerrariaServerAPI.Tests/BaseTest.cs
+++ b/TerrariaServerAPI.Tests/BaseTest.cs
@@ -15,19 +15,19 @@ public class BaseTest
 		{
 			var are = new AutoResetEvent(false);
 			Exception? error = null;
-			On.Terraria.Main.hook_DedServ cb = (On.Terraria.Main.orig_DedServ orig, Terraria.Main instance) =>
+			HookEvents.HookDelegate<global::Terraria.Main,HookEvents.Terraria.Main. DedServEventArgs> cb = (instance, args) =>
 			{
 				instance.Initialize();
 				are.Set();
 				_initialized = true;
 			};
-			On.Terraria.Main.DedServ += cb;
+			HookEvents.Terraria.Main.DedServ += cb;
 
 			global::TerrariaApi.Server.Program.Main(new string[] { });
 
 			_initialized = are.WaitOne(TimeSpan.FromSeconds(30));
 
-			On.Terraria.Main.DedServ -= cb;
+			HookEvents.Terraria.Main.DedServ -= cb;
 
 			Assert.That(_initialized, Is.True);
 			Assert.That(error, Is.Null);

--- a/TerrariaServerAPI.Tests/BaseTest.cs
+++ b/TerrariaServerAPI.Tests/BaseTest.cs
@@ -1,7 +1,5 @@
 ﻿using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
-using System.Threading;
 
 namespace TerrariaServerAPI.Tests;
 
@@ -16,24 +14,20 @@ public class BaseTest
 
 		if (!_initialized)
 		{
-			AutoResetEvent are = new(false);
-			Exception? error = null;
+			bool invoked = false;
 			HookEvents.HookDelegate<global::Terraria.Main, HookEvents.Terraria.Main.DedServEventArgs> cb = (instance, args) =>
 			{
-				instance.Initialize();
-				are.Set();
-				_initialized = true;
+				invoked = true;
+				// DedServ typically requires input, so no need to continue execution
+				args.ContinueExecution = false;
 			};
 			HookEvents.Terraria.Main.DedServ += cb;
 
 			global::TerrariaApi.Server.Program.Main([]);
 
-			_initialized = are.WaitOne(TimeSpan.FromSeconds(30));
-
 			HookEvents.Terraria.Main.DedServ -= cb;
 
-			Assert.That(_initialized, Is.True);
-			Assert.That(error, Is.Null);
+			Assert.That(invoked, Is.True);
 		}
 	}
 }

--- a/TerrariaServerAPI.Tests/BaseTest.cs
+++ b/TerrariaServerAPI.Tests/BaseTest.cs
@@ -1,6 +1,5 @@
 ﻿using NUnit.Framework;
 using System.Runtime.InteropServices;
-using Terraria.Utilities;
 
 namespace TerrariaServerAPI.Tests;
 
@@ -11,27 +10,28 @@ public class BaseTest
 	[OneTimeSetUp]
 	public void EnsureInitialised()
 	{
-		TestContext.Out.WriteLine($"Test architecture {RuntimeInformation.ProcessArchitecture}");
-
 		if (!_initialized)
 		{
+			TestContext.Out.WriteLine($"Test architecture {RuntimeInformation.ProcessArchitecture}");
+
 			bool invoked = false;
-			HookEvents.HookDelegate<global::Terraria.Main, HookEvents.Terraria.Main.DedServEventArgs> cb = (instance, args) =>
+			HookEvents.HookDelegate<Terraria.Main, HookEvents.Terraria.Main.DedServEventArgs> cb = (instance, args) =>
 			{
 				invoked = true;
 				// DedServ typically requires input, so no need to continue execution
 				args.ContinueExecution = false;
 				// DedServ calls the following, which is needed for subsequent tests
-				global::Terraria.Main.rand = new UnifiedRandom();
 				instance.Initialize();
 			};
 			HookEvents.Terraria.Main.DedServ += cb;
 
-			global::TerrariaApi.Server.Program.Main([]);
+			TerrariaApi.Server.Program.Main([]);
 
 			HookEvents.Terraria.Main.DedServ -= cb;
 
 			Assert.That(invoked, Is.True);
+
+			_initialized = true;
 		}
 	}
 }

--- a/TerrariaServerAPI.Tests/BaseTest.cs
+++ b/TerrariaServerAPI.Tests/BaseTest.cs
@@ -1,5 +1,6 @@
 ﻿using NUnit.Framework;
 using System;
+using System.Runtime.InteropServices;
 using System.Threading;
 
 namespace TerrariaServerAPI.Tests;
@@ -20,6 +21,7 @@ public class BaseTest
 				instance.Initialize();
 				are.Set();
 				_initialized = true;
+				Console.WriteLine($"Server init process successful for architecture {RuntimeInformation.ProcessArchitecture}");
 			};
 			HookEvents.Terraria.Main.DedServ += cb;
 

--- a/TerrariaServerAPI.Tests/BaseTest.cs
+++ b/TerrariaServerAPI.Tests/BaseTest.cs
@@ -20,6 +20,8 @@ public class BaseTest
 				invoked = true;
 				// DedServ typically requires input, so no need to continue execution
 				args.ContinueExecution = false;
+				// DedServ calls the following method, which is needed for subsequent tests
+				instance.Initialize();
 			};
 			HookEvents.Terraria.Main.DedServ += cb;
 

--- a/TerrariaServerAPI.Tests/ServerInitTests.cs
+++ b/TerrariaServerAPI.Tests/ServerInitTests.cs
@@ -1,4 +1,5 @@
 using NUnit.Framework;
+using System.Runtime.InteropServices;
 
 namespace TerrariaServerAPI.Tests;
 
@@ -8,5 +9,30 @@ public class ServerInitTests : BaseTest
 	public void EnsureBoots()
 	{
 		EnsureInitialised();
+	}
+
+	[Test]
+	public void EnsureRuntimeDetours()
+	{
+		// Platform exclude doesnt support arm64, so manual check it is...
+		if (RuntimeInformation.ProcessArchitecture == Architecture.Arm64)
+			Assert.Ignore("Test is not supported on ARM64 architecture.");
+
+		TestContext.Out.WriteLine($"Test architecture {RuntimeInformation.ProcessArchitecture}");
+
+		bool invoked = false;
+
+		On.Terraria.Main.hook_DedServ callback = (orig, self) =>
+		{
+			invoked = true;
+			// DedServ typically requires input, so no need to continue execution
+		};
+		On.Terraria.Main.DedServ += callback;
+
+		global::TerrariaApi.Server.Program.Main([]);
+
+		On.Terraria.Main.DedServ -= callback;
+
+		Assert.That(invoked, Is.True);
 	}
 }

--- a/TerrariaServerAPI.Tests/ServerInitTests.cs
+++ b/TerrariaServerAPI.Tests/ServerInitTests.cs
@@ -22,16 +22,12 @@ public class ServerInitTests : BaseTest
 
 		bool invoked = false;
 
-		On.Terraria.Main.hook_DedServ callback = (orig, self) =>
-		{
-			invoked = true;
-			// DedServ typically requires input, so no need to continue execution
-		};
-		On.Terraria.Main.DedServ += callback;
+		On.Terraria.Program.hook_RunGame callback = (orig) => invoked = true;
+		On.Terraria.Program.RunGame += callback;
 
-		global::TerrariaApi.Server.Program.Main([]);
+		Terraria.Program.RunGame();
 
-		On.Terraria.Main.DedServ -= callback;
+		On.Terraria.Program.RunGame -= callback;
 
 		Assert.That(invoked, Is.True);
 	}

--- a/TerrariaServerAPI.Tests/TerrariaServerAPI.Tests.csproj
+++ b/TerrariaServerAPI.Tests/TerrariaServerAPI.Tests.csproj
@@ -1,19 +1,22 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFramework>net6.0</TargetFramework>
+		<TargetFramework>net9.0</TargetFramework>
 		<Nullable>enable</Nullable>
 
 		<IsPackable>false</IsPackable>
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="BenchmarkDotNet" Version="0.13.2" />
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.1" />
-		<PackageReference Include="NUnit" Version="3.13.3" />
-		<PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
-		<PackageReference Include="NUnit.Analyzers" Version="3.3.0" />
-		<PackageReference Include="coverlet.collector" Version="3.1.2">
+		<PackageReference Include="BenchmarkDotNet" Version="0.14.0" />
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+		<PackageReference Include="NUnit" Version="4.3.2" />
+		<PackageReference Include="NUnit3TestAdapter" Version="4.6.0" />
+		<PackageReference Include="NUnit.Analyzers" Version="4.5.0">
+		  <PrivateAssets>all</PrivateAssets>
+		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+		</PackageReference>
+		<PackageReference Include="coverlet.collector" Version="6.0.3">
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 			<PrivateAssets>all</PrivateAssets>
 		</PackageReference>

--- a/TerrariaServerAPI/TerrariaApi.Server/HookManager.cs
+++ b/TerrariaServerAPI/TerrariaApi.Server/HookManager.cs
@@ -24,7 +24,7 @@ namespace TerrariaApi.Server
 					ServerApi.ApiVersion,
 					Main.versionNumber2,
 					Main.curRelease,
-					typeof(OTAPI.Hooks).Assembly.GetName().Version
+					OTAPI.Common.VersionShort
 				);
 				ServerApi.Initialize(Environment.GetCommandLineArgs(), Main.instance);
 			}

--- a/TerrariaServerAPI/TerrariaApi.Server/Hooking/GameHooks.cs
+++ b/TerrariaServerAPI/TerrariaApi.Server/Hooking/GameHooks.cs
@@ -1,80 +1,80 @@
-﻿using Microsoft.Xna.Framework;
-using OTAPI;
+﻿using OTAPI;
 
-namespace TerrariaApi.Server.Hooking
+namespace TerrariaApi.Server.Hooking;
+
+internal static class GameHooks
 {
-	internal static class GameHooks
+	private static HookManager _hookManager;
+
+	/// <summary>
+	/// Attaches any of the OTAPI Game hooks to the existing <see cref="HookManager"/> implementation
+	/// </summary>
+	/// <param name="hookManager">HookManager instance which will receive the events</param>
+	public static void AttachTo(HookManager hookManager)
 	{
-		private static HookManager _hookManager;
+		_hookManager = hookManager;
 
-		/// <summary>
-		/// Attaches any of the OTAPI Game hooks to the existing <see cref="HookManager"/> implementation
-		/// </summary>
-		/// <param name="hookManager">HookManager instance which will receive the events</param>
-		public static void AttachTo(HookManager hookManager)
+		HookEvents.Terraria.Main.Update += OnUpdate;
+		HookEvents.Terraria.Main.Initialize += OnInitialize;
+		HookEvents.Terraria.Netplay.StartServer += OnStartServer;
+
+		Hooks.WorldGen.HardmodeTilePlace += OnHardmodeTilePlace;
+		Hooks.WorldGen.HardmodeTileUpdate += OnHardmodeTileUpdate;
+		Hooks.Item.MechSpawn += OnItemMechSpawn;
+		Hooks.NPC.MechSpawn += OnNpcMechSpawn;
+	}
+
+	private static void OnUpdate(Terraria.Main instance, HookEvents.Terraria.Main.UpdateEventArgs args)
+	{
+		if (!args.ContinueExecution) return;
+		args.ContinueExecution = false;
+		_hookManager.InvokeGameUpdate();
+		args.OriginalMethod(args.gameTime);
+		_hookManager.InvokeGamePostUpdate();
+	}
+
+	private static void OnHardmodeTileUpdate(object sender, Hooks.WorldGen.HardmodeTileUpdateEventArgs e)
+	{
+		if (_hookManager.InvokeGameHardmodeTileUpdate(e.X, e.Y, e.Type))
 		{
-			_hookManager = hookManager;
-
-			On.Terraria.Main.Update += OnUpdate;
-			On.Terraria.Main.Initialize += OnInitialize;
-			On.Terraria.Netplay.StartServer += OnStartServer;
-
-			Hooks.WorldGen.HardmodeTilePlace += OnHardmodeTilePlace;
-			Hooks.WorldGen.HardmodeTileUpdate += OnHardmodeTileUpdate;
-			Hooks.Item.MechSpawn += OnItemMechSpawn;
-			Hooks.NPC.MechSpawn += OnNpcMechSpawn;
+			e.Result = HookResult.Cancel;
 		}
+	}
 
-		private static void OnUpdate(On.Terraria.Main.orig_Update orig, Terraria.Main instance, GameTime gameTime)
+	private static void OnHardmodeTilePlace(object sender, Hooks.WorldGen.HardmodeTilePlaceEventArgs e)
+	{
+		if (_hookManager.InvokeGameHardmodeTileUpdate(e.X, e.Y, e.Type))
 		{
-			_hookManager.InvokeGameUpdate();
-			orig(instance, gameTime);
-			_hookManager.InvokeGamePostUpdate();
+			e.Result = HardmodeTileUpdateResult.Cancel;
 		}
+	}
 
-		private static void OnHardmodeTileUpdate(object sender, Hooks.WorldGen.HardmodeTileUpdateEventArgs e)
+	private static void OnInitialize(Terraria.Main instance, HookEvents.Terraria.Main.InitializeEventArgs args)
+	{
+		if (!args.ContinueExecution) return;
+		HookManager.InitialiseAPI();
+		_hookManager.InvokeGameInitialize();
+	}
+
+	private static void OnStartServer(object? sender, HookEvents.Terraria.Netplay.StartServerEventArgs args)
+	{
+		if (!args.ContinueExecution) return;
+		_hookManager.InvokeGamePostInitialize();
+	}
+
+	private static void OnItemMechSpawn(object sender, Hooks.Item.MechSpawnEventArgs e)
+	{
+		if (!_hookManager.InvokeGameStatueSpawn(e.Num2, e.Num3, e.Num, (int)(e.X / 16f), (int)(e.Y / 16f), e.Type, false))
 		{
-			if (_hookManager.InvokeGameHardmodeTileUpdate(e.X, e.Y, e.Type))
-			{
-				e.Result = HookResult.Cancel;
-			}
+			e.Result = HookResult.Cancel;
 		}
+	}
 
-		private static void OnHardmodeTilePlace(object sender, Hooks.WorldGen.HardmodeTilePlaceEventArgs e)
+	private static void OnNpcMechSpawn(object sender, Hooks.NPC.MechSpawnEventArgs e)
+	{
+		if (!_hookManager.InvokeGameStatueSpawn(e.Num2, e.Num3, e.Num, (int)(e.X / 16f), (int)(e.Y / 16f), e.Type, true))
 		{
-			if (_hookManager.InvokeGameHardmodeTileUpdate(e.X, e.Y, e.Type))
-			{
-				e.Result = HardmodeTileUpdateResult.Cancel;
-			}
-		}
-
-		private static void OnInitialize(On.Terraria.Main.orig_Initialize orig, Terraria.Main instance)
-		{
-			HookManager.InitialiseAPI();
-			_hookManager.InvokeGameInitialize();
-			orig(instance);
-		}
-
-		private static void OnStartServer(On.Terraria.Netplay.orig_StartServer orig)
-		{
-			_hookManager.InvokeGamePostInitialize();
-			orig();
-		}
-
-		private static void OnItemMechSpawn(object sender, Hooks.Item.MechSpawnEventArgs e)
-		{
-			if (!_hookManager.InvokeGameStatueSpawn(e.Num2, e.Num3, e.Num, (int)(e.X / 16f), (int)(e.Y / 16f), e.Type, false))
-			{
-				e.Result = HookResult.Cancel;
-			}
-		}
-
-		private static void OnNpcMechSpawn(object sender, Hooks.NPC.MechSpawnEventArgs e)
-		{
-			if (!_hookManager.InvokeGameStatueSpawn(e.Num2, e.Num3, e.Num, (int)(e.X / 16f), (int)(e.Y / 16f), e.Type, true))
-			{
-				e.Result = HookResult.Cancel;
-			}
+			e.Result = HookResult.Cancel;
 		}
 	}
 }

--- a/TerrariaServerAPI/TerrariaApi.Server/Hooking/NetHooks.cs
+++ b/TerrariaServerAPI/TerrariaApi.Server/Hooking/NetHooks.cs
@@ -171,6 +171,7 @@ internal class NetHooks
 	static void OnConnectionAccepted(object? sender, HookEvents.Terraria.Netplay.OnConnectionAcceptedEventArgs args)
 	{
 		if (!args.ContinueExecution) return;
+		args.ContinueExecution = false;
 		int slot = FindNextOpenClientSlot();
 		if (slot != -1)
 		{

--- a/TerrariaServerAPI/TerrariaApi.Server/Hooking/NetHooks.cs
+++ b/TerrariaServerAPI/TerrariaApi.Server/Hooking/NetHooks.cs
@@ -1,187 +1,184 @@
-﻿using Microsoft.Xna.Framework;
-using OTAPI;
+﻿using OTAPI;
 using System;
 using Terraria;
-using Terraria.Localization;
 using Terraria.Net;
 
-namespace TerrariaApi.Server.Hooking
+namespace TerrariaApi.Server.Hooking;
+
+internal class NetHooks
 {
-	internal class NetHooks
+	private static HookManager _hookManager;
+
+	public static readonly object syncRoot = new();
+
+	/// <summary>
+	/// Attaches any of the OTAPI Net hooks to the existing <see cref="HookManager"/> implementation
+	/// </summary>
+	/// <param name="hookManager">HookManager instance which will receive the events</param>
+	public static void AttachTo(HookManager hookManager)
 	{
-		private static HookManager _hookManager;
+		_hookManager = hookManager;
 
-		public static readonly object syncRoot = new object();
+		HookEvents.Terraria.NetMessage.greetPlayer += OnGreetPlayer;
+		HookEvents.Terraria.Netplay.OnConnectionAccepted += OnConnectionAccepted;
+		HookEvents.Terraria.Chat.ChatHelper.BroadcastChatMessage += OnBroadcastChatMessage;
+		HookEvents.Terraria.Net.NetManager.SendData += OnSendNetData;
 
-		/// <summary>
-		/// Attaches any of the OTAPI Net hooks to the existing <see cref="HookManager"/> implementation
-		/// </summary>
-		/// <param name="hookManager">HookManager instance which will receive the events</param>
-		public static void AttachTo(HookManager hookManager)
+		Hooks.NetMessage.SendData += OnSendData;
+		Hooks.NetMessage.SendBytes += OnSendBytes;
+		Hooks.MessageBuffer.GetData += OnReceiveData;
+		Hooks.MessageBuffer.NameCollision += OnNameCollision;
+	}
+
+	static void OnBroadcastChatMessage(object? sender, HookEvents.Terraria.Chat.ChatHelper.BroadcastChatMessageEventArgs args)
+	{
+		if (!args.ContinueExecution) return;
+		float r = args.color.R, g = args.color.G, b = args.color.B;
+
+		var cancel = _hookManager.InvokeServerBroadcast(ref args.text, ref r, ref g, ref b);
+
+		if (!cancel)
 		{
-			_hookManager = hookManager;
-
-			On.Terraria.NetMessage.greetPlayer += OnGreetPlayer;
-			On.Terraria.Netplay.OnConnectionAccepted += OnConnectionAccepted;
-			On.Terraria.Chat.ChatHelper.BroadcastChatMessage += OnBroadcastChatMessage;
-			On.Terraria.Net.NetManager.SendData += OnSendNetData;
-
-			Hooks.NetMessage.SendData += OnSendData;
-			Hooks.NetMessage.SendBytes += OnSendBytes;
-			Hooks.MessageBuffer.GetData += OnReceiveData;
-			Hooks.MessageBuffer.NameCollision += OnNameCollision;
+			args.color = new Microsoft.Xna.Framework.Color(r, g, b);
 		}
 
-		static void OnBroadcastChatMessage(On.Terraria.Chat.ChatHelper.orig_BroadcastChatMessage orig, NetworkText text, Color color, int excludedPlayer)
+		args.ContinueExecution = !cancel;
+	}
+
+	static void OnSendData(object sender, Hooks.NetMessage.SendDataEventArgs e)
+	{
+		if (e.Event == HookEvent.Before)
 		{
-			float r = color.R, g = color.G, b = color.B;
-
-			var cancel = _hookManager.InvokeServerBroadcast(ref text, ref r, ref g, ref b);
-
-			if (!cancel)
-			{
-				color.R = (byte)r;
-				color.G = (byte)g;
-				color.B = (byte)b;
-
-				orig(text, color, excludedPlayer);
-			}
-		}
-
-		static void OnSendData(object sender, Hooks.NetMessage.SendDataEventArgs e)
-		{
-			if (e.Event == HookEvent.Before)
-			{
-				var msgType = e.MsgType;
-				var remoteClient = e.RemoteClient;
-				var ignoreClient = e.IgnoreClient;
-				var text = e.Text;
-				var number = e.Number;
-				var number2 = e.Number2;
-				var number3 = e.Number3;
-				var number4 = e.Number4;
-				var number5 = e.Number5;
-				var number6 = e.Number6;
-				var number7 = e.Number7;
-				if (_hookManager.InvokeNetSendData
-				(
-					ref msgType,
-					ref remoteClient,
-					ref ignoreClient,
-					ref text,
-					ref number,
-					ref number2,
-					ref number3,
-					ref number4,
-					ref number5,
-					ref number6,
-					ref number7
-				))
-				{
-					e.Result = HookResult.Cancel;
-				}
-
-				e.MsgType = msgType;
-				e.RemoteClient = remoteClient;
-				e.IgnoreClient = ignoreClient;
-				e.Text = text;
-				e.Number = number;
-				e.Number2 = number2;
-				e.Number3 = number3;
-				e.Number4 = number4;
-				e.Number5 = number5;
-				e.Number6 = number6;
-				e.Number7 = number7;
-			}
-		}
-
-		static void OnSendNetData(On.Terraria.Net.NetManager.orig_SendData orig, NetManager netmanager, Terraria.Net.Sockets.ISocket socket, NetPacket packet)
-		{
-			if (!_hookManager.InvokeNetSendNetData
+			var msgType = e.MsgType;
+			var remoteClient = e.RemoteClient;
+			var ignoreClient = e.IgnoreClient;
+			var text = e.Text;
+			var number = e.Number;
+			var number2 = e.Number2;
+			var number3 = e.Number3;
+			var number4 = e.Number4;
+			var number5 = e.Number5;
+			var number6 = e.Number6;
+			var number7 = e.Number7;
+			if (_hookManager.InvokeNetSendData
 			(
-				ref netmanager,
-				ref socket,
-				ref packet
+				ref msgType,
+				ref remoteClient,
+				ref ignoreClient,
+				ref text,
+				ref number,
+				ref number2,
+				ref number3,
+				ref number4,
+				ref number5,
+				ref number6,
+				ref number7
 			))
 			{
-				orig(netmanager, socket, packet);
+				e.Result = HookResult.Cancel;
 			}
-		}
 
-		static void OnReceiveData(object sender, Hooks.MessageBuffer.GetDataEventArgs e)
+			e.MsgType = msgType;
+			e.RemoteClient = remoteClient;
+			e.IgnoreClient = ignoreClient;
+			e.Text = text;
+			e.Number = number;
+			e.Number2 = number2;
+			e.Number3 = number3;
+			e.Number4 = number4;
+			e.Number5 = number5;
+			e.Number6 = number6;
+			e.Number7 = number7;
+		}
+	}
+
+	static void OnSendNetData(NetManager netmanager, HookEvents.Terraria.Net.NetManager.SendDataEventArgs args)
+	{
+		if (!args.ContinueExecution) return;
+		if (_hookManager.InvokeNetSendNetData
+		(
+			ref netmanager,
+			ref args.socket,
+			ref args.packet
+		))
 		{
-			if (!Enum.IsDefined(typeof(PacketTypes), (int)e.PacketId))
+			args.ContinueExecution = false;
+		}
+	}
+
+	static void OnReceiveData(object sender, Hooks.MessageBuffer.GetDataEventArgs e)
+	{
+		if (!Enum.IsDefined(typeof(PacketTypes), (int)e.PacketId))
+		{
+			e.Result = HookResult.Cancel;
+		}
+		else
+		{
+			var msgId = e.PacketId;
+			var readOffset = e.ReadOffset;
+			var length = e.Length;
+
+			if (_hookManager.InvokeNetGetData(ref msgId, e.Instance, ref readOffset, ref length))
 			{
 				e.Result = HookResult.Cancel;
 			}
-			else
-			{
-				var msgId = e.PacketId;
-				var readOffset = e.ReadOffset;
-				var length = e.Length;
 
-				if (_hookManager.InvokeNetGetData(ref msgId, e.Instance, ref readOffset, ref length))
+			e.PacketId = msgId;
+			e.ReadOffset = readOffset;
+			e.Length = length;
+		}
+	}
+
+	static void OnGreetPlayer(object? sender, HookEvents.Terraria.NetMessage.greetPlayerEventArgs args)
+	{
+		if (!args.ContinueExecution) return;
+		if (_hookManager.InvokeNetGreetPlayer(args.plr))
+			args.ContinueExecution = false;
+	}
+
+	static void OnSendBytes(object sender, Hooks.NetMessage.SendBytesEventArgs e)
+	{
+		if (_hookManager.InvokeNetSendBytes(Netplay.Clients[e.RemoteClient], e.Data, e.Offset, e.Size))
+		{
+			e.Result = HookResult.Cancel;
+		}
+	}
+
+	static void OnNameCollision(object sender, Hooks.MessageBuffer.NameCollisionEventArgs e)
+	{
+		if (_hookManager.InvokeNetNameCollision(e.Player.whoAmI, e.Player.name))
+		{
+			e.Result = HookResult.Cancel;
+		}
+	}
+
+	static void OnConnectionAccepted(object? sender, HookEvents.Terraria.Netplay.OnConnectionAcceptedEventArgs args)
+	{
+		if (!args.ContinueExecution) return;
+		int slot = FindNextOpenClientSlot();
+		if (slot != -1)
+		{
+			Netplay.Clients[slot].Reset();
+			Netplay.Clients[slot].Socket = args.client;
+		}
+		if (FindNextOpenClientSlot() == -1)
+		{
+			Netplay.StopListening();
+		}
+	}
+
+	static int FindNextOpenClientSlot()
+	{
+		lock (syncRoot)
+		{
+			for (int i = 0; i < Main.maxNetPlayers; i++)
+			{
+				if (!Netplay.Clients[i].IsConnected())
 				{
-					e.Result = HookResult.Cancel;
-				}
-
-				e.PacketId = msgId;
-				e.ReadOffset = readOffset;
-				e.Length = length;
-			}
-		}
-
-		static void OnGreetPlayer(On.Terraria.NetMessage.orig_greetPlayer orig, int plr)
-		{
-			if (_hookManager.InvokeNetGreetPlayer(plr))
-				return;
-
-			orig(plr);
-		}
-
-		static void OnSendBytes(object sender, Hooks.NetMessage.SendBytesEventArgs e)
-		{
-			if (_hookManager.InvokeNetSendBytes(Netplay.Clients[e.RemoteClient], e.Data, e.Offset, e.Size))
-			{
-				e.Result = HookResult.Cancel;
-			}
-		}
-
-		static void OnNameCollision(object sender, Hooks.MessageBuffer.NameCollisionEventArgs e)
-		{
-			if (_hookManager.InvokeNetNameCollision(e.Player.whoAmI, e.Player.name))
-			{
-				e.Result = HookResult.Cancel;
-			}
-		}
-
-		static void OnConnectionAccepted(On.Terraria.Netplay.orig_OnConnectionAccepted orig, Terraria.Net.Sockets.ISocket client)
-		{
-			int slot = FindNextOpenClientSlot();
-			if (slot != -1)
-			{
-				Netplay.Clients[slot].Reset();
-				Netplay.Clients[slot].Socket = client;
-			}
-			if (FindNextOpenClientSlot() == -1)
-			{
-				Netplay.StopListening();
-			}
-		}
-
-		static int FindNextOpenClientSlot()
-		{
-			lock (syncRoot)
-			{
-				for (int i = 0; i < Main.maxNetPlayers; i++)
-				{
-					if (!Netplay.Clients[i].IsConnected())
-					{
-						return i;
-					}
+					return i;
 				}
 			}
-			return -1;
 		}
+		return -1;
 	}
 }

--- a/TerrariaServerAPI/TerrariaApi.Server/Hooking/NetHooks.cs
+++ b/TerrariaServerAPI/TerrariaApi.Server/Hooking/NetHooks.cs
@@ -23,7 +23,7 @@ internal class NetHooks
 		HookEvents.Terraria.Netplay.OnConnectionAccepted += OnConnectionAccepted;
 		HookEvents.Terraria.Chat.ChatHelper.BroadcastChatMessage += OnBroadcastChatMessage;
 		HookEvents.Terraria.Net.NetManager.SendData += OnSendNetData;
-			On.Terraria.Netplay.UpdateConnectedClients += OnUpdateConnectedClients;
+		HookEvents.Terraria.Netplay.UpdateConnectedClients += OnUpdateConnectedClients;
 
 		Hooks.NetMessage.SendData += OnSendData;
 		Hooks.NetMessage.SendBytes += OnSendBytes;
@@ -31,14 +31,16 @@ internal class NetHooks
 		Hooks.MessageBuffer.NameCollision += OnNameCollision;
 	}
 
-		static void OnUpdateConnectedClients(On.Terraria.Netplay.orig_UpdateConnectedClients orig)
+	static void OnUpdateConnectedClients(object? sender, HookEvents.Terraria.Netplay.UpdateConnectedClientsEventArgs args)
+	{
+		if (!args.ContinueExecution) return;
+		args.ContinueExecution = false;
+		args.OriginalMethod();
+		if (ServerApi.ForceUpdate)
 		{
-			orig();
-			if (ServerApi.ForceUpdate)
-			{
-				Terraria.Netplay.HasClients = true;
-			}
+			Terraria.Netplay.HasClients = true;
 		}
+	}
 
 	static void OnBroadcastChatMessage(object? sender, HookEvents.Terraria.Chat.ChatHelper.BroadcastChatMessageEventArgs args)
 	{

--- a/TerrariaServerAPI/TerrariaApi.Server/Hooking/NpcHooks.cs
+++ b/TerrariaServerAPI/TerrariaApi.Server/Hooking/NpcHooks.cs
@@ -2,132 +2,84 @@
 using OTAPI;
 using Terraria;
 
-namespace TerrariaApi.Server.Hooking
+namespace TerrariaApi.Server.Hooking;
+
+internal static class NpcHooks
 {
-	internal static class NpcHooks
+	private static HookManager _hookManager;
+
+	/// <summary>
+	/// Attaches any of the OTAPI Npc hooks to the existing <see cref="HookManager"/> implementation
+	/// </summary>
+	/// <param name="hookManager">HookManager instance which will receive the events</param>
+	public static void AttachTo(HookManager hookManager)
 	{
-		private static HookManager _hookManager;
+		_hookManager = hookManager;
 
-		/// <summary>
-		/// Attaches any of the OTAPI Npc hooks to the existing <see cref="HookManager"/> implementation
-		/// </summary>
-		/// <param name="hookManager">HookManager instance which will receive the events</param>
-		public static void AttachTo(HookManager hookManager)
+		HookEvents.Terraria.NPC.SetDefaults += OnSetDefaultsById;
+		HookEvents.Terraria.NPC.SetDefaultsFromNetId += OnSetDefaultsFromNetId;
+		HookEvents.Terraria.NPC.StrikeNPC += OnStrike;
+		HookEvents.Terraria.NPC.Transform += OnTransform;
+		HookEvents.Terraria.NPC.AI += OnAI;
+
+		Hooks.NPC.Spawn += OnSpawn;
+		Hooks.NPC.DropLoot += OnDropLoot;
+		Hooks.NPC.BossBag += OnBossBagItem;
+		Hooks.NPC.Killed += OnKilled;
+	}
+
+	static void OnKilled(object sender, Hooks.NPC.KilledEventArgs e)
+	{
+		_hookManager.InvokeNpcKilled(e.Npc);
+	}
+
+	static void OnSetDefaultsById(NPC npc, HookEvents.Terraria.NPC.SetDefaultsEventArgs args)
+	{
+		if (!args.ContinueExecution) return;
+		if (_hookManager.InvokeNpcSetDefaultsInt(ref args.Type, npc))
+			args.ContinueExecution = false;
+	}
+
+	static void OnSetDefaultsFromNetId(NPC npc, HookEvents.Terraria.NPC.SetDefaultsFromNetIdEventArgs args)
+	{
+		if (!args.ContinueExecution) return;
+		if (_hookManager.InvokeNpcNetDefaults(ref args.id, npc))
+			args.ContinueExecution = false;
+	}
+
+	static void OnStrike(NPC npc, HookEvents.Terraria.NPC.StrikeNPCEventArgs args)
+	{
+		if (!args.ContinueExecution) return;
+		if (args.entity is Player player)
 		{
-			_hookManager = hookManager;
-
-			On.Terraria.NPC.SetDefaults += OnSetDefaultsById;
-			On.Terraria.NPC.SetDefaultsFromNetId += OnSetDefaultsFromNetId;
-			On.Terraria.NPC.StrikeNPC += OnStrike;
-			On.Terraria.NPC.Transform += OnTransform;
-			On.Terraria.NPC.AI += OnAI;
-
-			Hooks.NPC.Spawn += OnSpawn;
-			Hooks.NPC.DropLoot += OnDropLoot;
-			Hooks.NPC.BossBag += OnBossBagItem;
-			Hooks.NPC.Killed += OnKilled;
-		}
-
-		static void OnKilled(object sender, Hooks.NPC.KilledEventArgs e)
-		{
-			_hookManager.InvokeNpcKilled(e.Npc);
-		}
-
-		static void OnSetDefaultsById(On.Terraria.NPC.orig_SetDefaults orig, NPC npc, int type, NPCSpawnParams spawnparams)
-		{
-			if (_hookManager.InvokeNpcSetDefaultsInt(ref type, npc))
-				return;
-
-			orig(npc, type, spawnparams);
-		}
-
-		static void OnSetDefaultsFromNetId(On.Terraria.NPC.orig_SetDefaultsFromNetId orig, NPC npc, int id, NPCSpawnParams spawnparams)
-		{
-			if (_hookManager.InvokeNpcNetDefaults(ref id, npc))
-				return;
-
-			orig(npc, id, spawnparams);
-		}
-
-		static double OnStrike(On.Terraria.NPC.orig_StrikeNPC orig, NPC npc, int Damage, float knockBack, int hitDirection, bool crit, bool noEffect, bool fromNet, Entity entity)
-		{
-			if (entity is Player player)
+			if (_hookManager.InvokeNpcStrike(npc, ref args.Damage, ref args.knockBack, ref args.hitDirection, ref args.crit, ref args.noEffect, ref args.fromNet, player))
 			{
-				if (_hookManager.InvokeNpcStrike(npc, ref Damage, ref knockBack, ref hitDirection, ref crit, ref noEffect, ref fromNet, player))
-				{
-					return 0;
-				}
-			}
-
-			return orig(npc, Damage, knockBack, hitDirection, crit, noEffect, fromNet, entity);
-		}
-
-		static void OnTransform(On.Terraria.NPC.orig_Transform orig, NPC npc, int newType)
-		{
-			if (_hookManager.InvokeNpcTransformation(npc.whoAmI))
-				return;
-
-			orig(npc, newType);
-		}
-
-		static void OnSpawn(object sender, Hooks.NPC.SpawnEventArgs e)
-		{
-			var index = e.Index;
-			if (_hookManager.InvokeNpcSpawn(ref index))
-			{
-				e.Result = HookResult.Cancel;
-				e.Index = index;
+				args.ContinueExecution = false;
+				args.HookReturnValue = 0;
 			}
 		}
+	}
 
-		static void OnDropLoot(object sender, Hooks.NPC.DropLootEventArgs e)
+	static void OnTransform(NPC npc, HookEvents.Terraria.NPC.TransformEventArgs args)
+	{
+		if (!args.ContinueExecution) return;
+		if (_hookManager.InvokeNpcTransformation(npc.whoAmI))
+			args.ContinueExecution = false;
+	}
+
+	static void OnSpawn(object sender, Hooks.NPC.SpawnEventArgs e)
+	{
+		var index = e.Index;
+		if (_hookManager.InvokeNpcSpawn(ref index))
 		{
-			if (e.Event == HookEvent.Before)
-			{
-				var Width = e.Width;
-				var Height = e.Height;
-				var Type = e.Type;
-				var Stack = e.Stack;
-				var noBroadcast = e.NoBroadcast;
-				var pfix = e.Pfix;
-				var noGrabDelay = e.NoGrabDelay;
-				var reverseLookup = e.ReverseLookup;
-
-				var position = new Vector2(e.X, e.Y);
-				if (_hookManager.InvokeNpcLootDrop
-				(
-					ref position,
-					ref Width,
-					ref Height,
-					ref Type,
-					ref Stack,
-					ref noBroadcast,
-					ref pfix,
-					e.Npc.type,
-					e.Npc.whoAmI,
-					ref noGrabDelay,
-					ref reverseLookup
-				))
-				{
-					e.X = (int)position.X;
-					e.Y = (int)position.Y;
-					e.Result = HookResult.Cancel;
-				}
-				e.X = (int)position.X;
-				e.Y = (int)position.Y;
-
-				e.Width = Width;
-				e.Height = Height;
-				e.Type = Type;
-				e.Stack = Stack;
-				e.NoBroadcast = noBroadcast;
-				e.Pfix = pfix;
-				e.NoGrabDelay = noGrabDelay;
-				e.ReverseLookup = reverseLookup;
-			}
+			e.Result = HookResult.Cancel;
+			e.Index = index;
 		}
+	}
 
-		static void OnBossBagItem(object sender, Hooks.NPC.BossBagEventArgs e)
+	static void OnDropLoot(object sender, Hooks.NPC.DropLootEventArgs e)
+	{
+		if (e.Event == HookEvent.Before)
 		{
 			var Width = e.Width;
 			var Height = e.Height;
@@ -138,10 +90,10 @@ namespace TerrariaApi.Server.Hooking
 			var noGrabDelay = e.NoGrabDelay;
 			var reverseLookup = e.ReverseLookup;
 
-			var positon = new Vector2(e.X, e.Y);
-			if (_hookManager.InvokeDropBossBag
+			var position = new Vector2(e.X, e.Y);
+			if (_hookManager.InvokeNpcLootDrop
 			(
-				ref positon,
+				ref position,
 				ref Width,
 				ref Height,
 				ref Type,
@@ -154,8 +106,12 @@ namespace TerrariaApi.Server.Hooking
 				ref reverseLookup
 			))
 			{
+				e.X = (int)position.X;
+				e.Y = (int)position.Y;
 				e.Result = HookResult.Cancel;
 			}
+			e.X = (int)position.X;
+			e.Y = (int)position.Y;
 
 			e.Width = Width;
 			e.Height = Height;
@@ -166,13 +122,52 @@ namespace TerrariaApi.Server.Hooking
 			e.NoGrabDelay = noGrabDelay;
 			e.ReverseLookup = reverseLookup;
 		}
+	}
 
-		static void OnAI(On.Terraria.NPC.orig_AI orig, NPC npc)
+	static void OnBossBagItem(object sender, Hooks.NPC.BossBagEventArgs e)
+	{
+		var Width = e.Width;
+		var Height = e.Height;
+		var Type = e.Type;
+		var Stack = e.Stack;
+		var noBroadcast = e.NoBroadcast;
+		var pfix = e.Pfix;
+		var noGrabDelay = e.NoGrabDelay;
+		var reverseLookup = e.ReverseLookup;
+
+		var positon = new Vector2(e.X, e.Y);
+		if (_hookManager.InvokeDropBossBag
+		(
+			ref positon,
+			ref Width,
+			ref Height,
+			ref Type,
+			ref Stack,
+			ref noBroadcast,
+			ref pfix,
+			e.Npc.type,
+			e.Npc.whoAmI,
+			ref noGrabDelay,
+			ref reverseLookup
+		))
 		{
-			if (_hookManager.InvokeNpcAIUpdate(npc))
-				return;
-
-			orig(npc);
+			e.Result = HookResult.Cancel;
 		}
+
+		e.Width = Width;
+		e.Height = Height;
+		e.Type = Type;
+		e.Stack = Stack;
+		e.NoBroadcast = noBroadcast;
+		e.Pfix = pfix;
+		e.NoGrabDelay = noGrabDelay;
+		e.ReverseLookup = reverseLookup;
+	}
+
+	static void OnAI(NPC npc, HookEvents.Terraria.NPC.AIEventArgs args)
+	{
+		if (!args.ContinueExecution) return;
+		if (_hookManager.InvokeNpcAIUpdate(npc))
+			args.ContinueExecution = false;
 	}
 }

--- a/TerrariaServerAPI/TerrariaApi.Server/Hooking/ProjectileHooks.cs
+++ b/TerrariaServerAPI/TerrariaApi.Server/Hooking/ProjectileHooks.cs
@@ -1,36 +1,35 @@
-﻿using OTAPI;
-using Terraria;
+﻿using Terraria;
 
-namespace TerrariaApi.Server.Hooking
+namespace TerrariaApi.Server.Hooking;
+
+internal static class ProjectileHooks
 {
-	internal static class ProjectileHooks
+	private static HookManager _hookManager;
+
+	/// <summary>
+	/// Attaches any of the OTAPI Projectile hooks to the existing <see cref="HookManager"/> implementation
+	/// </summary>
+	/// <param name="hookManager">HookManager instance which will receive the events</param>
+	public static void AttachTo(HookManager hookManager)
 	{
-		private static HookManager _hookManager;
+		_hookManager = hookManager;
 
-		/// <summary>
-		/// Attaches any of the OTAPI Projectile hooks to the existing <see cref="HookManager"/> implementation
-		/// </summary>
-		/// <param name="hookManager">HookManager instance which will receive the events</param>
-		public static void AttachTo(HookManager hookManager)
-		{
-			_hookManager = hookManager;
+		HookEvents.Terraria.Projectile.SetDefaults += OnSetDefaults;
+		HookEvents.Terraria.Projectile.AI += OnAI;
+	}
 
-			On.Terraria.Projectile.SetDefaults += OnSetDefaults;
-			On.Terraria.Projectile.AI += OnAI;
-		}
+	private static void OnSetDefaults(Projectile projectile, HookEvents.Terraria.Projectile.SetDefaultsEventArgs args)
+	{
+		if (!args.ContinueExecution) return;
+		args.ContinueExecution = false;
+		args.OriginalMethod(args.Type);
+		_hookManager.InvokeProjectileSetDefaults(ref args.Type, projectile);
+	}
 
-		private static void OnSetDefaults(On.Terraria.Projectile.orig_SetDefaults orig, Projectile projectile, int type)
-		{
-			orig(projectile, type);
-			_hookManager.InvokeProjectileSetDefaults(ref type, projectile);
-		}
-
-		private static void OnAI(On.Terraria.Projectile.orig_AI orig, Projectile projectile)
-		{
-			if (_hookManager.InvokeProjectileAIUpdate(projectile))
-				return;
-
-			orig(projectile);
-		}
+	private static void OnAI(Projectile projectile, HookEvents.Terraria.Projectile.AIEventArgs args)
+	{
+		if (!args.ContinueExecution) return;
+		if (_hookManager.InvokeProjectileAIUpdate(projectile))
+			args.ContinueExecution = false;
 	}
 }

--- a/TerrariaServerAPI/TerrariaApi.Server/Hooking/WiringHooks.cs
+++ b/TerrariaServerAPI/TerrariaApi.Server/Hooking/WiringHooks.cs
@@ -1,29 +1,28 @@
 ﻿using OTAPI;
 using Terraria;
 
-namespace TerrariaApi.Server.Hooking
+namespace TerrariaApi.Server.Hooking;
+
+internal static class WiringHooks
 {
-	internal static class WiringHooks
+	private static HookManager _hookManager;
+
+	/// <summary>
+	/// Attaches any of the OTAPI Wiring hooks to the existing <see cref="HookManager"/> implementation
+	/// </summary>
+	/// <param name="hookManager">HookManager instance which will receive the events</param>
+	public static void AttachTo(HookManager hookManager)
 	{
-		private static HookManager _hookManager;
+		_hookManager = hookManager;
 
-		/// <summary>
-		/// Attaches any of the OTAPI Wiring hooks to the existing <see cref="HookManager"/> implementation
-		/// </summary>
-		/// <param name="hookManager">HookManager instance which will receive the events</param>
-		public static void AttachTo(HookManager hookManager)
+		Hooks.Wiring.AnnouncementBox += OnAnnouncementBox;
+	}
+
+	static void OnAnnouncementBox(object sender, Hooks.Wiring.AnnouncementBoxEventArgs e)
+	{
+		if (_hookManager.InvokeWireTriggerAnnouncementBox(Wiring.CurrentUser, e.X, e.Y, e.SignId, Main.sign[e.SignId].text))
 		{
-			_hookManager = hookManager;
-
-			Hooks.Wiring.AnnouncementBox += OnAnnouncementBox;
-		}
-
-		static void OnAnnouncementBox(object sender, Hooks.Wiring.AnnouncementBoxEventArgs e)
-		{
-			if (_hookManager.InvokeWireTriggerAnnouncementBox(Wiring.CurrentUser, e.X, e.Y, e.SignId, Main.sign[e.SignId].text))
-			{
-				e.Result = HookResult.Cancel;
-			}
+			e.Result = HookResult.Cancel;
 		}
 	}
 }

--- a/TerrariaServerAPI/TerrariaApi.Server/Hooking/WorldHooks.cs
+++ b/TerrariaServerAPI/TerrariaApi.Server/Hooking/WorldHooks.cs
@@ -1,95 +1,89 @@
 ﻿using OTAPI;
 using Terraria;
 
-namespace TerrariaApi.Server.Hooking
+namespace TerrariaApi.Server.Hooking;
+
+internal static class WorldHooks
 {
-	internal static class WorldHooks
+	private static HookManager _hookManager;
+
+	/// <summary>
+	/// Attaches any of the OTAPI World hooks to the existing <see cref="HookManager"/> implementation
+	/// </summary>
+	/// <param name="hookManager">HookManager instance which will receive the events</param>
+	public static void AttachTo(HookManager hookManager)
 	{
-		private static HookManager _hookManager;
+		_hookManager = hookManager;
 
-		/// <summary>
-		/// Attaches any of the OTAPI World hooks to the existing <see cref="HookManager"/> implementation
-		/// </summary>
-		/// <param name="hookManager">HookManager instance which will receive the events</param>
-		public static void AttachTo(HookManager hookManager)
+		HookEvents.Terraria.IO.WorldFile.SaveWorld_Boolean_Boolean += WorldFile_SaveWorld;
+		HookEvents.Terraria.WorldGen.StartHardmode += WorldGen_StartHardmode;
+		HookEvents.Terraria.WorldGen.SpreadGrass += WorldGen_SpreadGrass;
+		HookEvents.Terraria.Main.checkXMas += Main_checkXMas;
+		HookEvents.Terraria.Main.checkHalloween += Main_checkHalloween;
+
+		Hooks.Collision.PressurePlate += OnPressurePlate;
+		Hooks.WorldGen.Meteor += OnDropMeteor;
+	}
+
+	static void OnPressurePlate(object sender, Hooks.Collision.PressurePlateEventArgs e)
+	{
+		if (e.Entity is NPC npc)
 		{
-			_hookManager = hookManager;
-
-			On.Terraria.IO.WorldFile.SaveWorld_bool_bool += WorldFile_SaveWorld;
-			On.Terraria.WorldGen.StartHardmode += WorldGen_StartHardmode;
-			On.Terraria.WorldGen.SpreadGrass += WorldGen_SpreadGrass;
-			On.Terraria.Main.checkXMas += Main_checkXMas;
-			On.Terraria.Main.checkHalloween += Main_checkHalloween;
-
-			Hooks.Collision.PressurePlate += OnPressurePlate;
-			Hooks.WorldGen.Meteor += OnDropMeteor;
-		}
-
-		static void OnPressurePlate(object sender, Hooks.Collision.PressurePlateEventArgs e)
-		{
-			if (e.Entity is NPC npc)
-			{
-				if (_hookManager.InvokeNpcTriggerPressurePlate(npc, e.X, e.Y))
-					e.Result = HookResult.Cancel;
-			}
-			else if (e.Entity is Player player)
-			{
-				if (_hookManager.InvokePlayerTriggerPressurePlate(player, e.X, e.Y))
-					e.Result = HookResult.Cancel;
-			}
-			else if (e.Entity is Projectile projectile)
-			{
-				if (_hookManager.InvokeProjectileTriggerPressurePlate(projectile, e.X, e.Y))
-					e.Result = HookResult.Cancel;
-			}
-		}
-
-		static void WorldFile_SaveWorld(On.Terraria.IO.WorldFile.orig_SaveWorld_bool_bool orig, bool useCloudSaving, bool resetTime)
-		{
-			if (_hookManager.InvokeWorldSave(resetTime))
-				return;
-
-			orig(useCloudSaving, resetTime);
-		}
-
-		private static void WorldGen_StartHardmode(On.Terraria.WorldGen.orig_StartHardmode orig)
-		{
-			if (_hookManager.InvokeWorldStartHardMode())
-				return;
-
-			orig();
-		}
-
-		static void OnDropMeteor(object sender, Hooks.WorldGen.MeteorEventArgs e)
-		{
-			if (_hookManager.InvokeWorldMeteorDrop(e.X, e.Y))
-			{
+			if (_hookManager.InvokeNpcTriggerPressurePlate(npc, e.X, e.Y))
 				e.Result = HookResult.Cancel;
-			}
 		}
-
-		private static void Main_checkXMas(On.Terraria.Main.orig_checkXMas orig)
+		else if (e.Entity is Player player)
 		{
-			if (_hookManager.InvokeWorldChristmasCheck(ref Terraria.Main.xMas))
-				return;
-
-			orig();
+			if (_hookManager.InvokePlayerTriggerPressurePlate(player, e.X, e.Y))
+				e.Result = HookResult.Cancel;
 		}
-
-		private static void Main_checkHalloween(On.Terraria.Main.orig_checkHalloween orig)
+		else if (e.Entity is Projectile projectile)
 		{
-			if (_hookManager.InvokeWorldHalloweenCheck(ref Main.halloween))
-				return;
-
-			orig();
+			if (_hookManager.InvokeProjectileTriggerPressurePlate(projectile, e.X, e.Y))
+				e.Result = HookResult.Cancel;
 		}
+	}
 
-		private static void WorldGen_SpreadGrass(On.Terraria.WorldGen.orig_SpreadGrass orig, int i, int j, int dirt, int grass, bool repeat, TileColorCache color)
+	static void WorldFile_SaveWorld(object? sender, HookEvents.Terraria.IO.WorldFile.SaveWorld_Boolean_BooleanEventArgs args)
+	{
+		if (!args.ContinueExecution) return;
+		if (_hookManager.InvokeWorldSave(args.resetTime))
+			args.ContinueExecution = false;
+	}
+
+	private static void WorldGen_StartHardmode(object? sender, HookEvents.Terraria.WorldGen.StartHardmodeEventArgs args)
+	{
+		if (!args.ContinueExecution) return;
+		if (_hookManager.InvokeWorldStartHardMode())
+			args.ContinueExecution = false;
+	}
+
+	static void OnDropMeteor(object sender, Hooks.WorldGen.MeteorEventArgs e)
+	{
+		if (_hookManager.InvokeWorldMeteorDrop(e.X, e.Y))
 		{
-			if (_hookManager.InvokeWorldGrassSpread(i, j, dirt, grass, repeat, color))
-				return;
-
-			orig(i, j, dirt, grass, repeat, color);
+			e.Result = HookResult.Cancel;
 		}
+	}
+
+	private static void Main_checkXMas(object? sender, HookEvents.Terraria.Main.checkXMasEventArgs args)
+	{
+		if (!args.ContinueExecution) return;
+		if (_hookManager.InvokeWorldChristmasCheck(ref Terraria.Main.xMas))
+			args.ContinueExecution = false;
+	}
+
+	private static void Main_checkHalloween(object? sender, HookEvents.Terraria.Main.checkHalloweenEventArgs args)
+	{
+		if (!args.ContinueExecution) return;
+		if (_hookManager.InvokeWorldHalloweenCheck(ref Main.halloween))
+			args.ContinueExecution = false;
+	}
+
+	private static void WorldGen_SpreadGrass(object? sender, HookEvents.Terraria.WorldGen.SpreadGrassEventArgs args)
+	{
+		if (!args.ContinueExecution) return;
+		if (_hookManager.InvokeWorldGrassSpread(args.i, args.j, args.dirt, args.grass, args.repeat, args.color))
+			args.ContinueExecution = false;
 	}
 }

--- a/TerrariaServerAPI/TerrariaServerAPI.csproj
+++ b/TerrariaServerAPI/TerrariaServerAPI.csproj
@@ -23,6 +23,6 @@
 	<ItemGroup>
 		<PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
 		<PackageReference Include="System.Diagnostics.PerformanceCounter" Version="9.0.0" />
-		<PackageReference Include="OTAPI.Upcoming" Version="3.2.3" />
+		<PackageReference Include="OTAPI.Upcoming" Version="3.2.4" />
 	</ItemGroup>
 </Project>

--- a/TerrariaServerAPI/TerrariaServerAPI.csproj
+++ b/TerrariaServerAPI/TerrariaServerAPI.csproj
@@ -23,6 +23,6 @@
 	<ItemGroup>
 		<PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
 		<PackageReference Include="System.Diagnostics.PerformanceCounter" Version="9.0.0" />
-		<PackageReference Include="OTAPI.Upcoming" Version="3.2.2" />
+		<PackageReference Include="OTAPI.Upcoming" Version="3.2.3" />
 	</ItemGroup>
 </Project>

--- a/TerrariaServerAPI/TerrariaServerAPI.csproj
+++ b/TerrariaServerAPI/TerrariaServerAPI.csproj
@@ -4,7 +4,7 @@
 	<PropertyGroup>
 		<OutputType>Library</OutputType>
 		<AssemblyName>TerrariaServer</AssemblyName> <!-- old plugins reference this, if it changes, they break -->
-		<TargetFramework>net6.0</TargetFramework>
+		<TargetFramework>net9.0</TargetFramework>
 		<AllowUnsafeBlocks>true</AllowUnsafeBlocks>
 		<GenerateDocumentationFile>True</GenerateDocumentationFile>
 		<RunPostBuildEvent>Always</RunPostBuildEvent>
@@ -21,8 +21,8 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
-		<PackageReference Include="System.Diagnostics.PerformanceCounter" Version="6.0.1" />
-		<PackageReference Include="OTAPI.Upcoming" Version="3.1.20" />
+		<PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+		<PackageReference Include="System.Diagnostics.PerformanceCounter" Version="9.0.0" />
+		<PackageReference Include="OTAPI.Upcoming" Version="3.2.1" />
 	</ItemGroup>
 </Project>

--- a/TerrariaServerAPI/TerrariaServerAPI.csproj
+++ b/TerrariaServerAPI/TerrariaServerAPI.csproj
@@ -23,6 +23,6 @@
 	<ItemGroup>
 		<PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
 		<PackageReference Include="System.Diagnostics.PerformanceCounter" Version="9.0.0" />
-		<PackageReference Include="OTAPI.Upcoming" Version="3.2.1" />
+		<PackageReference Include="OTAPI.Upcoming" Version="3.2.2" />
 	</ItemGroup>
 </Project>


### PR DESCRIPTION
### This PR aims for the following:
- Target frameworks & workflows updated to net9.0
- OTAPI and other packages updated
- Moved to [generated OTAPI static hooks](https://github.com/SignatureBeef/ModFramework.NET/blob/default/ModFramework/Emitters/HookEmitter.cs#L581), making MonoMod RD optional/supplemental (though, OTAPI.Runtime.dll is still included for those still utilising it, and works on net9)
  - _Note: File scoped namespaces was utilised, which is why the diff is more than expected._
- Expanded workflow to test each platform
- Reduced OTAPI/ModFw console outputs (e.g. no tile ctor print, short version codes etc)

### Considerations that may flow through to a TShock PR (or sooner if desired):
- OTAPI Static Hook namespace naming preferences e.g. `HookEvents.*` vs MonoMod RD `On.*`
- OTAPI Static Hook EventArgs property naming preferences e.g. `ContinueExecution`, `HookReturnValue`
- If any extra static hooks are needed, current list includes most methods from the following Terraria types: 
  - `Main, Item, NetMessage, Netplay, NPC, WorldGen, Chat.ChatHelper, IO.WorldFile, Net.NetManager, Projectile, RemoteClient, Liquid, Program.`
- Apple Silicon / ARM64 testing
- Plugin updates: at the moment should just be a matter of ticking up to net9.0, and matching dependencies/updating

### Screenshots

#### Windows x64
![image](https://github.com/user-attachments/assets/96a0b4ee-570e-424c-887b-248bc0556c22)
![image](https://github.com/user-attachments/assets/9bd52bdb-008b-428f-800a-299ab82a6c70)


#### MacOS Arm64
<img width="908" alt="image" src="https://github.com/user-attachments/assets/57076b79-a299-48e1-adca-62a6a31b7d43" />
<img width="923" alt="image" src="https://github.com/user-attachments/assets/efdd73e4-06d1-4926-a56e-18caffdd5059" />
Joining Mac Arm64 from Win64:

![image](https://github.com/user-attachments/assets/a0c8a18b-dc1c-469c-8ba2-f86116a5a634)
