### PR TITLE
feat(plugin): Add `Call` method to `TerrariaPlugin` base class

### DIFF
--- a/TerrariaServerAPI/TerrariaApi.Server/TerrariaPlugin.cs
+++ b/TerrariaServerAPI/TerrariaApi.Server/TerrariaPlugin.cs
@@ -130,5 +130,14 @@ namespace TerrariaApi.Server
 		/// Invoked after the plugin is constructed. Initialization logic should occur here.
 		///</summary>
 		public abstract void Initialize();
+
+		/// <summary>
+		/// Implements weak inter-plugin communication. Allows interaction with other plugins without referencing their types or namespaces.
+		/// </summary>
+		public virtual object Call(params object[] args)
+		{
+			return null;
+		}
+
 	}
 }


### PR DESCRIPTION
Adds a virtual Call method with params object[] args parameter to allow plugins to implement custom method invocation functionality without referencing their types or namespaces.

## Example
### Called Plugin (eg. A rank plugin)
```csharp
public override object Call(params object[] args)
{
  if (args.Length < 2)
      return null;
  
  var command = args[0] as string;
  var player = args[0] as TSPlayer;

  switch (command)
  {
      case "GetRankData":
        return GetRankData(player);
      case "ResetRankData":
        return ResetRankData(player);
      default:
        return null;
  }
}
```
### Calling Plugin
```csharp
var rankPlugin = ServerApi.Plugins.FirstOrDefault(p => p.Plugin.Name == "RankPlugin");

if (rankPlugin == null)
{
    player.SendErrorMessage("Rank plugin not available!");
    return;
}

var rankData = rankPlugin?.Plugin.Call("GetRankData", player) as string;
player.SendSuccessMessage(rankData);
```