### PR TITLE
Add System.IO.Packaging dependency for Terraria 1.4.5.0

### DIFF
--- a/TerrariaServerAPI.Tests/TileGenerateTests.cs
+++ b/TerrariaServerAPI.Tests/TileGenerateTests.cs
@@ -24,13 +24,13 @@ public class TileGenerateTests : TileBenchmarks
 		Main.tile = provider;
 
 		WorldGen.generatingWorld = true;
-		Main.rand = new UnifiedRandom(9999);
-		WorldGen.gen = true;
+		Main.ActiveWorldFileData.SetSeed("seeeeeeeeeed");
+		Main.rand = new UnifiedRandom(Main.ActiveWorldFileData.Seed);
 		Main.menuMode = 888;
 
 		WorldGen.clearWorld();
 
-		WorldGen.GenerateWorld(9999);
+		WorldGen.GenerateWorld();
 	}
 
 	[Test]

--- a/TerrariaServerAPI/TerrariaApi.Server/Hooking/ItemHooks.cs
+++ b/TerrariaServerAPI/TerrariaApi.Server/Hooking/ItemHooks.cs
@@ -15,7 +15,7 @@ internal static class ItemHooks
 	{
 		_hookManager = hookManager;
 
-		HookEvents.Terraria.Item.SetDefaults_Int32_Boolean_ItemVariant += OnSetDefaults;
+		HookEvents.Terraria.Item.SetDefaults += OnSetDefaults;
 		HookEvents.Terraria.Item.netDefaults += OnNetDefaults;
 
 		Hooks.Chest.QuickStack += OnQuickStack;
@@ -28,7 +28,7 @@ internal static class ItemHooks
 			args.ContinueExecution = false;
 	}
 
-	private static void OnSetDefaults(Item item, HookEvents.Terraria.Item.SetDefaults_Int32_Boolean_ItemVariantEventArgs args)
+	private static void OnSetDefaults(Item item, HookEvents.Terraria.Item.SetDefaultsEventArgs args)
 	{
 		if (!args.ContinueExecution) return;
 		if (_hookManager.InvokeItemSetDefaultsInt(ref args.Type, item, args.variant))

--- a/TerrariaServerAPI/TerrariaServerAPI.csproj
+++ b/TerrariaServerAPI/TerrariaServerAPI.csproj
@@ -23,6 +23,6 @@
 	<ItemGroup>
 		<PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
 		<PackageReference Include="System.Diagnostics.PerformanceCounter" Version="9.0.0" />
-		<PackageReference Include="OTAPI.Upcoming" Version="3.2.4" />
+		<PackageReference Include="OTAPI.Upcoming" Version="3.3.1" />
 	</ItemGroup>
 </Project>

--- a/TerrariaServerAPI/TerrariaServerAPI.csproj
+++ b/TerrariaServerAPI/TerrariaServerAPI.csproj
@@ -23,6 +23,7 @@
 	<ItemGroup>
 		<PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
 		<PackageReference Include="System.Diagnostics.PerformanceCounter" Version="9.0.0" />
+		<PackageReference Include="System.IO.Packaging" Version="9.0.0" />
 		<PackageReference Include="OTAPI.Upcoming" Version="3.3.1" />
 	</ItemGroup>
 </Project>


### PR DESCRIPTION
## Summary                                                                                                                                               
  Add `System.IO.Packaging` NuGet package to fix server startup crash in Terraria 1.4.5.
## Problem
  Terraria 1.4.5 now uses `System.IO.Packaging` in `WorldFile.GetAllMetadata()` to read world file metadata. Without this dependency, the server crashes on startup:
<img width="2486" height="822" alt="4aafd60d11089fa6aff326be2f7e06a8" src="https://github.com/user-attachments/assets/3503b204-443b-41c1-8dda-1b646c319565" />
## Changes                                                                                                                                               
  - Added `<PackageReference Include="System.IO.Packaging" Version="9.0.0" />` to `TerrariaServerAPI.csproj`
  - Based on 787058e changes
