### PR TITLE
Update OTAPI to 3.3.10

### DIFF
--- a/TerrariaServerAPI/TerrariaServerAPI.csproj
+++ b/TerrariaServerAPI/TerrariaServerAPI.csproj
@@ -23,6 +23,6 @@
 	<ItemGroup>
 		<PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
 		<PackageReference Include="System.Diagnostics.PerformanceCounter" Version="9.0.0" />
-		<PackageReference Include="OTAPI.Upcoming" Version="3.3.9" />
+		<PackageReference Include="OTAPI.Upcoming" Version="3.3.10" />
 	</ItemGroup>
 </Project>


### PR DESCRIPTION
Updates OTAPI to 3.3.10 for the new CraftingRequests.CanCraftFromChest hook needed for [#3250](https://github.com/Pryaxis/TShock/pull/3250)