### PR TITLE
Reduce CPU usage when stin/input is not available

### DIFF
--- a/TerrariaServerAPI/TerrariaApi.Server/Hooking/ServerHooks.cs
+++ b/TerrariaServerAPI/TerrariaApi.Server/Hooking/ServerHooks.cs
@@ -18,6 +18,7 @@ internal static class ServerHooks
 		_hookManager = hookManager;
 
 		HookEvents.Terraria.Main.startDedInput += Main_startDedInput;
+		HookEvents.Terraria.Main.ReadLineInput += Main_ReadLineInput;
 		HookEvents.Terraria.RemoteClient.Reset += RemoteClient_Reset;
 		Hooks.Main.CommandProcess += OnProcess;
 	}
@@ -35,6 +36,23 @@ internal static class ServerHooks
 
 		args.OriginalMethod();
 	}
+
+#nullable enable
+	/// <summary>
+	/// Hooks the default ReadLineInput method to add a small delay when Console.ReadLine() returns null.
+	/// For example, some docker instances may experience a 100% CPU usage due to this vanilla thread implementation.
+	/// </summary>
+	static void Main_ReadLineInput(object? sender, HookEvents.Terraria.Main.ReadLineInputEventArgs args)
+	{
+		args.ContinueExecution = false;
+
+		string? text;
+		while ((text = Console.ReadLine()) is null)
+			System.Threading.Thread.Sleep(100);
+
+		args.HookReturnValue = text;
+	}
+#nullable disable
 
 	static void OnProcess(object sender, Hooks.Main.CommandProcessEventArgs e)
 	{


### PR DESCRIPTION
See: https://github.com/Pryaxis/TShock/issues/3131 

`-disable-commands` is a thing which will disable the command thread altogether, however, this PR will (hopefully) implement better handling for those retaining the command thread.

Before:
<img width="1113" height="534" alt="image" src="https://github.com/user-attachments/assets/8547b907-9655-4bad-b7e6-63e9045b907a" />

After:
<img width="1113" height="534" alt="image" src="https://github.com/user-attachments/assets/e13a0493-978f-4f9a-b58c-835737417d3a" />
