### PR TITLE
Update to OTAPI 3.3.11

### DIFF
--- a/TerrariaServerAPI/TerrariaApi.Server/Hooking/WorldHooks.cs
+++ b/TerrariaServerAPI/TerrariaApi.Server/Hooking/WorldHooks.cs
@@ -15,7 +15,7 @@ internal static class WorldHooks
 	{
 		_hookManager = hookManager;
 
-		HookEvents.Terraria.IO.WorldFile.SaveWorld_Boolean_Boolean += WorldFile_SaveWorld;
+		HookEvents.Terraria.IO.WorldFile._SaveWorld += WorldFile_SaveWorld;
 		HookEvents.Terraria.WorldGen.StartHardmode += WorldGen_StartHardmode;
 		HookEvents.Terraria.WorldGen.SpreadGrass += WorldGen_SpreadGrass;
 		HookEvents.Terraria.Main.checkXMas += Main_checkXMas;
@@ -48,7 +48,7 @@ internal static class WorldHooks
 		}
 	}
 
-	static void WorldFile_SaveWorld(object? sender, HookEvents.Terraria.IO.WorldFile.SaveWorld_Boolean_BooleanEventArgs args)
+	static void WorldFile_SaveWorld(object? sender, HookEvents.Terraria.IO.WorldFile._SaveWorldEventArgs args)
 	{
 		if (!args.ContinueExecution) return;
 		if (_hookManager.InvokeWorldSave(args.resetTime))

--- a/TerrariaServerAPI/TerrariaServerAPI.csproj
+++ b/TerrariaServerAPI/TerrariaServerAPI.csproj
@@ -23,6 +23,6 @@
 	<ItemGroup>
 		<PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
 		<PackageReference Include="System.Diagnostics.PerformanceCounter" Version="9.0.0" />
-		<PackageReference Include="OTAPI.Upcoming" Version="3.3.10" />
+		<PackageReference Include="OTAPI.Upcoming" Version="3.3.11" />
 	</ItemGroup>
 </Project>


### PR DESCRIPTION
This PR updates to OTAPI 3.3.11 for Terraria 1.4.5.6.
Main change is the Terraria.IO.WorldFile.SaveWorld overload was renamed to _SaveWorld, with a few more arguments, which not (currently) used in TSAPI.