### PR TITLE
Port TSAPI hooks to Terraria 1.4.5.7 (OTAPI 3.3.12)

### DIFF
--- a/TerrariaServerAPI/TerrariaApi.Server/Hooking/NetHooks.cs
+++ b/TerrariaServerAPI/TerrariaApi.Server/Hooking/NetHooks.cs
@@ -1,6 +1,7 @@
 ﻿using OTAPI;
 using System;
 using Terraria;
+using Terraria.Localization;
 using Terraria.Net;
 
 namespace TerrariaApi.Server.Hooking;
@@ -38,7 +39,7 @@ internal class NetHooks
 		args.OriginalMethod();
 		if (ServerApi.ForceUpdate)
 		{
-			Terraria.Netplay.HasClients = true;
+			Terraria.Netplay.HasFullyConnectedClients = true;
 		}
 	}
 
@@ -189,11 +190,12 @@ internal class NetHooks
 		{
 			Netplay.Clients[slot].Reset();
 			Netplay.Clients[slot].Socket = args.client;
+			return;
 		}
-		if (FindNextOpenClientSlot() == -1)
-		{
-			Netplay.StopListening();
-		}
+
+		// 1.4.5.7 removed Netplay.StopListening(). Vanilla now kicks the incoming connection
+		// when every slot is taken rather than tearing the listener down, so mirror that.
+		Netplay.KickClient(args.client, NetworkText.FromKey("CLI.ServerIsFull"));
 	}
 
 	static int FindNextOpenClientSlot()

--- a/TerrariaServerAPI/TerrariaApi.Server/Hooking/NpcHooks.cs
+++ b/TerrariaServerAPI/TerrariaApi.Server/Hooking/NpcHooks.cs
@@ -52,7 +52,9 @@ internal static class NpcHooks
 		if (!args.ContinueExecution) return;
 		if (args.entity is Player player)
 		{
-			if (_hookManager.InvokeNpcStrike(npc, ref args.Damage, ref args.knockBack, ref args.hitDirection, ref args.crit, ref args.noEffect, ref args.fromNet, player))
+			// TODO(1.4.5.7): NPC.StrikeNPC no longer has noEffect; kept in the TSAPI hook signature for plugin compat.
+			bool noEffect = false;
+			if (_hookManager.InvokeNpcStrike(npc, ref args.Damage, ref args.knockBack, ref args.hitDirection, ref args.crit, ref noEffect, ref args.fromNet, player))
 			{
 				args.ContinueExecution = false;
 				args.HookReturnValue = 0;

--- a/TerrariaServerAPI/TerrariaServerAPI.csproj
+++ b/TerrariaServerAPI/TerrariaServerAPI.csproj
@@ -23,6 +23,6 @@
 	<ItemGroup>
 		<PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
 		<PackageReference Include="System.Diagnostics.PerformanceCounter" Version="9.0.0" />
-		<PackageReference Include="OTAPI.Upcoming" Version="3.3.11" />
+		<PackageReference Include="OTAPI.Upcoming" Version="3.3.12" />
 	</ItemGroup>
 </Project>


### PR DESCRIPTION
Bumps `OTAPI.Upcoming` to `3.3.12` (the published 1.4.5.7 build) and fixes the three resulting compile breaks. This is the submodule half of a 1.4.5.7 port — TShock cannot build against 1.4.5.7 until this lands, so it needs to go first.

### Changes

- **`Netplay.HasClients` → `HasFullyConnectedClients`.** Straight rename in 1.4.5.7.
- **`Netplay.StopListening()` was removed.** Vanilla's `OnConnectionAccepted` now kicks the incoming connection with `CLI.ServerIsFull` when every slot is taken, instead of tearing the listener down. The hook mirrors that. `Netplay.IsListening` still exists but is never read anywhere in the assembly, so clearing it would have been a no-op.
- **`NPC.StrikeNPC` no longer carries `noEffect`.** It's kept in the `InvokeNpcStrike` signature for plugin compatibility and fed a local dummy, so no plugin-facing API break.

### Verification

Builds clean against `OTAPI.Upcoming` 3.3.12 from nuget.org, as part of a TShock tree that also builds clean (0 errors) with its launcher reference bumped to match. Behaviour was checked against the decompiled 1.4.5.7 `Terraria.Netplay` rather than guessed.

Not runtime-tested against a live client yet.

### Changelog

Updated TSAPI for Terraria 1.4.5.7 / OTAPI 3.3.12.