### PR TITLE
Bump OTAPI to 3.3.12 for Terraria 1.4.5.7 support

### DIFF
--- a/TerrariaServerAPI/TerrariaApi.Server/Hooking/NetHooks.cs
+++ b/TerrariaServerAPI/TerrariaApi.Server/Hooking/NetHooks.cs
@@ -38,7 +38,7 @@ internal class NetHooks
 		args.OriginalMethod();
 		if (ServerApi.ForceUpdate)
 		{
-			Terraria.Netplay.HasClients = true;
+			Terraria.Netplay.HasFullyConnectedClients = true;
 		}
 	}
 
@@ -192,7 +192,7 @@ internal class NetHooks
 		}
 		if (FindNextOpenClientSlot() == -1)
 		{
-			Netplay.StopListening();
+			Netplay.TcpListener?.StopListening();
 		}
 	}
 

--- a/TerrariaServerAPI/TerrariaApi.Server/Hooking/NpcHooks.cs
+++ b/TerrariaServerAPI/TerrariaApi.Server/Hooking/NpcHooks.cs
@@ -52,7 +52,10 @@ internal static class NpcHooks
 		if (!args.ContinueExecution) return;
 		if (args.entity is Player player)
 		{
-			if (_hookManager.InvokeNpcStrike(npc, ref args.Damage, ref args.knockBack, ref args.hitDirection, ref args.crit, ref args.noEffect, ref args.fromNet, player))
+			// 1.4.5.7 removed the noEffect parameter from NPC.StrikeNPC, so it is
+			// not part of the OTAPI hook args anymore; keep the internal API intact.
+			bool noEffect = false;
+			if (_hookManager.InvokeNpcStrike(npc, ref args.Damage, ref args.knockBack, ref args.hitDirection, ref args.crit, ref noEffect, ref args.fromNet, player))
 			{
 				args.ContinueExecution = false;
 				args.HookReturnValue = 0;

--- a/TerrariaServerAPI/TerrariaApi.Server/PacketTypes.cs
+++ b/TerrariaServerAPI/TerrariaApi.Server/PacketTypes.cs
@@ -159,8 +159,10 @@ public enum PacketTypes
 	RequestSection = 159,
 	SyncItemPosition = 160,
 	HostToken = 161,
-
-	// Mobile version packets
+	// 1.4.5.7: 162 is the NPC strike acknowledgement (DamageNPCAck).
+	// The old mobile-only aliases are kept as same-value members for API compatibility,
+	// matching how OTAPI retains deprecated members for older plugins.
+	DamageNPCAck = 162,
 	ServerInfo = 162,
 	PlayerPlatformInfo = 163
 }

--- a/TerrariaServerAPI/TerrariaServerAPI.csproj
+++ b/TerrariaServerAPI/TerrariaServerAPI.csproj
@@ -23,6 +23,6 @@
 	<ItemGroup>
 		<PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
 		<PackageReference Include="System.Diagnostics.PerformanceCounter" Version="9.0.0" />
-		<PackageReference Include="OTAPI.Upcoming" Version="3.3.11" />
+		<PackageReference Include="OTAPI.Upcoming" Version="3.3.12" />
 	</ItemGroup>
 </Project>


### PR DESCRIPTION
**English**

Updates TSAPI to OTAPI.Upcoming 3.3.12, which adds Terraria 1.4.5.7 support.

Changes:
- Bump `OTAPI.Upcoming` 3.3.11 → 3.3.12.
- `NetHooks`: `Netplay.HasClients` → `Netplay.HasFullyConnectedClients`; `Netplay.StopListening()` → `Netplay.TcpListener?.StopListening()` (the static method was removed in 1.4.5.7; `ISocket.StopListening` is kept).
- `NpcHooks`: `NPC.StrikeNPC` no longer takes a `noEffect` argument in 1.4.5.7; the public `InvokeNpcStrike` API is kept intact via a local variable.
- `PacketTypes`: packet 162 is now `DamageNPCAck` (new NPC-strike acknowledgement). The old `ServerInfo`/`PlayerPlatformInfo` members are kept as same-value aliases so existing plugins keep compiling.

Verified: `dotnet build` + tests pass; boot-tested with the vanilla 1.4.5.7 server – OTAPI reports `Protocol v1.4.5.7 (325)`.

**Changelog**
- Update TSAPI to support Terraria 1.4.5.7 (OTAPI 3.3.12).

---

**中文简介**

升级 TSAPI 至 OTAPI.Upcoming 3.3.12（Terraria 1.4.5.7 适配版）。

改动：
- `OTAPI.Upcoming` 3.3.11 → 3.3.12。
- `NetHooks`：`Netplay.HasClients` → `HasFullyConnectedClients`；`Netplay.StopListening()` → `Netplay.TcpListener?.StopListening()`（1.4.5.7 移除该静态方法，`ISocket.StopListening` 仍保留）。
- `NpcHooks`：1.4.5.7 的 `NPC.StrikeNPC` 不再有 `noEffect` 参数，以局部变量保持公共 `InvokeNpcStrike` API 不变。
- `PacketTypes`：162 号包现在是 `DamageNPCAck`（新增的 NPC 打击确认包）；保留旧 `ServerInfo`/`PlayerPlatformInfo` 为同值别名，避免旧插件编译失败。

已验证：构建 + 单测通过；用原版 1.4.5.7 服务器实测可启动（OTAPI 报告 `Protocol v1.4.5.7 (325)`）。

**Changelog**
- TSAPI 升级以支持 Terraria 1.4.5.7（OTAPI 3.3.12）。