### PR TITLE
fix/terraria 1.4.5.7 port

### DIFF
--- a/TerrariaServerAPI/TerrariaApi.Server/Hooking/NetHooks.cs
+++ b/TerrariaServerAPI/TerrariaApi.Server/Hooking/NetHooks.cs
@@ -38,7 +38,7 @@ internal class NetHooks
 		args.OriginalMethod();
 		if (ServerApi.ForceUpdate)
 		{
-			Terraria.Netplay.HasClients = true;
+			Terraria.Netplay.HasFullyConnectedClients = true;
 		}
 	}
 
@@ -192,7 +192,7 @@ internal class NetHooks
 		}
 		if (FindNextOpenClientSlot() == -1)
 		{
-			Netplay.StopListening();
+			Netplay.TcpListener?.StopListening();
 		}
 	}
 

--- a/TerrariaServerAPI/TerrariaApi.Server/Hooking/NpcHooks.cs
+++ b/TerrariaServerAPI/TerrariaApi.Server/Hooking/NpcHooks.cs
@@ -52,7 +52,10 @@ internal static class NpcHooks
 		if (!args.ContinueExecution) return;
 		if (args.entity is Player player)
 		{
-			if (_hookManager.InvokeNpcStrike(npc, ref args.Damage, ref args.knockBack, ref args.hitDirection, ref args.crit, ref args.noEffect, ref args.fromNet, player))
+			// 1.4.5.7 removed the noEffect parameter from NPC.StrikeNPC, so it is
+			// not part of the OTAPI hook args anymore; keep the internal API intact.
+			bool noEffect = false;
+			if (_hookManager.InvokeNpcStrike(npc, ref args.Damage, ref args.knockBack, ref args.hitDirection, ref args.crit, ref noEffect, ref args.fromNet, player))
 			{
 				args.ContinueExecution = false;
 				args.HookReturnValue = 0;

--- a/TerrariaServerAPI/TerrariaApi.Server/PacketTypes.cs
+++ b/TerrariaServerAPI/TerrariaApi.Server/PacketTypes.cs
@@ -159,8 +159,10 @@ public enum PacketTypes
 	RequestSection = 159,
 	SyncItemPosition = 160,
 	HostToken = 161,
-
-	// Mobile version packets
+	// 1.4.5.7: 162 is the NPC strike acknowledgement (DamageNPCAck).
+	// The old mobile-only aliases are kept as same-value members for API compatibility,
+	// matching how OTAPI retains deprecated members for older plugins.
+	DamageNPCAck = 162,
 	ServerInfo = 162,
 	PlayerPlatformInfo = 163
 }

--- a/TerrariaServerAPI/TerrariaServerAPI.csproj
+++ b/TerrariaServerAPI/TerrariaServerAPI.csproj
@@ -23,6 +23,6 @@
 	<ItemGroup>
 		<PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
 		<PackageReference Include="System.Diagnostics.PerformanceCounter" Version="9.0.0" />
-		<PackageReference Include="OTAPI.Upcoming" Version="3.3.11" />
+		<PackageReference Include="OTAPI.Upcoming" Version="3.3.12" />
 	</ItemGroup>
 </Project>


### PR DESCRIPTION
Stacked on #282 (@hufang360) — that PR gets 1.4.5.7 building, this makes NPCs actually spawn. Reduces to one commit once #282 merges.

Bug (from #281): server boots and clients connect, but no enemies ever spawn. Town NPCs are fine.

Cause: OTAPI 3.3.12 changed Hooks.NPC.InvokeCreate to take the slot and generation, so the hook is now responsible for placing the NPC in Main.npc. 3.3.11 did that inside NewNPC (Main.npc[index] = nPC; nPC.whoAmI = index; nPC.ResetForNewNPC();). 3.3.12 dropped those lines but its fallback still returns a bare new NPC(). Nothing subscribes to Hooks.NPC.Create, so every spawn applied SetDefaults/active/timeLeft to a detached instance that was never stored Main.npc[slot] stayed empty and GetAvailableNPCSlot handed back the same slot forever. 

Fix: subscribe to Hooks.NPC.Create and use the engine's own factory NPC.NewNPCInstanceInSlot(slot, generation) — it stores the instance, sets whoAmI, bumps the generation clients use for recycled slots, and clears stale cross-references via ResetNPCSlotData. OTAPI should arguably fix its fallback too; this makes TSAPI correct either way. Tested: .NET 9, linux-arm64, vanilla 1.4.5.7 client. Before: zero non-town NPCs, NewNPC called repeatedly always returning the same slot. After: enemies  spawn, despawn and sync normally.

Thanks @hufang360 for #282, @ZakFahey for the TShock-side port in Pryaxis/TShock#3299, and @bryldd for digging into the PR before.
